### PR TITLE
fixes the request channel title display issue

### DIFF
--- a/packages/assistify-help-request/lib/roomTypes/request.js
+++ b/packages/assistify-help-request/lib/roomTypes/request.js
@@ -39,7 +39,7 @@ export class RequestRoomType extends RoomTypeConfig {
 	}
 
 	roomName(roomData) {
-		return roomData.name;
+		return roomData.fname || roomData.name;
 	}
 
 	condition() {


### PR DESCRIPTION
Fixes #109 issue. 

Issue Background: The techinical slugified name of the request channel was displaye insteas of human readable name.

This is fixed now to display the name appropriately 