### PR TITLE
Feature/#24 deactivate closing comments

### DIFF
--- a/packages/assistify-defaults/server/roles.js
+++ b/packages/assistify-defaults/server/roles.js
@@ -179,7 +179,8 @@ const createConfigurationRole = function() {
 		'change-setting-Accounts_AllowedDomainsList',
 		'change-setting-Accounts_ManuallyApproveNewUsers',
 		'change-setting-Accounts_EmailVerification',
-		'change-setting-Accounts'
+		'change-setting-Accounts',
+		'change-setting-Assitify_Deactivate_request_closing_comments'
 	];
 
 	assignPermissions(CONFIGURATION_ROLE_NAME,

--- a/packages/assistify-defaults/server/roles.js
+++ b/packages/assistify-defaults/server/roles.js
@@ -180,7 +180,7 @@ const createConfigurationRole = function() {
 		'change-setting-Accounts_ManuallyApproveNewUsers',
 		'change-setting-Accounts_EmailVerification',
 		'change-setting-Accounts',
-		'change-setting-Assitify_Deactivate_request_closing_comments'
+		'change-setting-Assistify_Deactivate_request_closing_comments'
 	];
 
 	assignPermissions(CONFIGURATION_ROLE_NAME,

--- a/packages/assistify-help-request/client/views/tabbar/HelpRequestActions.js
+++ b/packages/assistify-help-request/client/views/tabbar/HelpRequestActions.js
@@ -1,7 +1,7 @@
 import {RocketChat, UiTextContext} from 'meteor/rocketchat:lib';
 
 const showClosingComment = function() {
-	return !!RocketChat.settings.get('Assitify_Deactivate_request_closing_comments');
+	return !RocketChat.settings.get('Assitify_Deactivate_request_closing_comments');
 };
 
 Template.HelpRequestActions.helpers({
@@ -55,7 +55,7 @@ Template.HelpRequestActions.events({
 		};
 
 		if (showClosingComment()) {
-			swalConfig = _.extend(swalConfig, {
+			swalConfig = Object.assign(swalConfig, {
 				type: 'input',
 				inputPlaceholder: t('Close_request_comment')
 			});
@@ -94,7 +94,7 @@ Template.HelpRequestActions.events({
 		};
 
 		if (showClosingComment()) {
-			swalConfig = _.extend(swalConfig, {
+			swalConfig = Object.assign(swalConfig, {
 				type: 'input',
 				inputPlaceholder: t('Please_add_a_comment')
 			});

--- a/packages/assistify-help-request/client/views/tabbar/HelpRequestActions.js
+++ b/packages/assistify-help-request/client/views/tabbar/HelpRequestActions.js
@@ -1,10 +1,9 @@
-import { RocketChat, UiTextContext } from 'meteor/rocketchat:lib';
+import {RocketChat, UiTextContext} from 'meteor/rocketchat:lib';
 
 const showClosingComment = function() {
-	if (RocketChat.settings.get('Assitify_Deactivate_request_closing_comments')) {
-		return 'input';
-	}
+	return !!RocketChat.settings.get('Assitify_Deactivate_request_closing_comments');
 };
+
 Template.HelpRequestActions.helpers({
 	helprequestOpen() {
 		const instance = Template.instance();
@@ -47,15 +46,22 @@ Template.HelpRequestActions.events({
 		event.preventDefault();
 		const warnText = RocketChat.roomTypes.roomTypes['r'].getUiText(UiTextContext.CLOSE_WARNING);
 
-		swal(_.extend({
+		let swalConfig = {
 			title: t('Closing_chat'),
 			text: warnText ? t(warnText) : '',
-			type: showClosingComment(),
-			inputPlaceholder: t('Close_request_comment'),
 			showCancelButton: true,
 			closeOnConfirm: false,
 			roomId: instance.data.roomId
-		}), (inputValue) => {
+		};
+
+		if (showClosingComment()) {
+			swalConfig = _.extend(swalConfig, {
+				type: 'input',
+				inputPlaceholder: t('Close_request_comment')
+			});
+		}
+
+		swal(swalConfig, (inputValue) => {
 			//inputValue is false on "cancel" and has a string value of the input if confirmed.
 			if (!(typeof inputValue === 'boolean' && inputValue === false)) {
 				Meteor.call('assistify:closeHelpRequest', this.roomId, {comment: inputValue}, function(error) {
@@ -80,14 +86,21 @@ Template.HelpRequestActions.events({
 	},
 	'click .close-livechat'(event) {
 		event.preventDefault();
-
-		swal({
+		let swalConfig = {
 			title: t('Closing_chat'),
 			type: showClosingComment(),
-			inputPlaceholder: t('Please_add_a_comment'),
 			showCancelButton: true,
 			closeOnConfirm: false
-		}, (inputValue) => {
+		};
+
+		if (showClosingComment()) {
+			swalConfig = _.extend(swalConfig, {
+				type: 'input',
+				inputPlaceholder: t('Please_add_a_comment')
+			});
+		}
+
+		swal(swalConfig, (inputValue) => {
 			//inputValue is false on "cancel" and has a string value of the input if confirmed.
 			if (!(typeof inputValue === 'boolean' && inputValue === false)) {
 

--- a/packages/assistify-help-request/client/views/tabbar/HelpRequestActions.js
+++ b/packages/assistify-help-request/client/views/tabbar/HelpRequestActions.js
@@ -1,5 +1,10 @@
 import { RocketChat, UiTextContext } from 'meteor/rocketchat:lib';
 
+const showClosingComment = function() {
+	if (RocketChat.settings.get('Assitify_Deactivate_request_closing_comments')) {
+		return 'input';
+	}
+};
 Template.HelpRequestActions.helpers({
 	helprequestOpen() {
 		const instance = Template.instance();
@@ -36,6 +41,7 @@ Template.HelpRequestActions.helpers({
 	}
 });
 
+
 Template.HelpRequestActions.events({
 	'click .close-helprequest'(event, instance) {
 		event.preventDefault();
@@ -44,7 +50,7 @@ Template.HelpRequestActions.events({
 		swal(_.extend({
 			title: t('Closing_chat'),
 			text: warnText ? t(warnText) : '',
-			type: 'input',
+			type: showClosingComment(),
 			inputPlaceholder: t('Close_request_comment'),
 			showCancelButton: true,
 			closeOnConfirm: false,

--- a/packages/assistify-help-request/client/views/tabbar/HelpRequestActions.js
+++ b/packages/assistify-help-request/client/views/tabbar/HelpRequestActions.js
@@ -1,7 +1,7 @@
 import {RocketChat, UiTextContext} from 'meteor/rocketchat:lib';
 
 const showClosingComment = function() {
-	return !RocketChat.settings.get('Assitify_Deactivate_request_closing_comments');
+	return !RocketChat.settings.get('Assistify_Deactivate_request_closing_comments');
 };
 
 Template.HelpRequestActions.helpers({

--- a/packages/assistify-help-request/client/views/tabbar/HelpRequestActions.js
+++ b/packages/assistify-help-request/client/views/tabbar/HelpRequestActions.js
@@ -83,7 +83,7 @@ Template.HelpRequestActions.events({
 
 		swal({
 			title: t('Closing_chat'),
-			type: 'input',
+			type: showClosingComment(),
 			inputPlaceholder: t('Please_add_a_comment'),
 			showCancelButton: true,
 			closeOnConfirm: false

--- a/packages/assistify-help-request/client/views/tabbar/HelpRequestActions.js
+++ b/packages/assistify-help-request/client/views/tabbar/HelpRequestActions.js
@@ -55,7 +55,7 @@ Template.HelpRequestActions.events({
 		};
 
 		if (showClosingComment()) {
-			swalConfig = Object.assign(swalConfig, {
+			swalConfig = _.extend(swalConfig, {
 				type: 'input',
 				inputPlaceholder: t('Close_request_comment')
 			});
@@ -94,7 +94,7 @@ Template.HelpRequestActions.events({
 		};
 
 		if (showClosingComment()) {
-			swalConfig = Object.assign(swalConfig, {
+			swalConfig = _.extend(swalConfig, {
 				type: 'input',
 				inputPlaceholder: t('Please_add_a_comment')
 			});

--- a/packages/assistify-help-request/config.js
+++ b/packages/assistify-help-request/config.js
@@ -26,6 +26,14 @@ Meteor.startup(() => {
 		section: 'General'
 	});
 
+	RocketChat.settings.add('Assitify_Deactivate_request_closing_comments', false, {
+		group: 'Assistify',
+		i18nLabel: 'Deactivate_close_comment',
+		type: 'boolean',
+		section:'General',
+		public: true
+	});
+
 	_createExpertsChannel();
 
 	RocketChat.theme.addPackageAsset(() => {

--- a/packages/assistify-help-request/config.js
+++ b/packages/assistify-help-request/config.js
@@ -26,7 +26,7 @@ Meteor.startup(() => {
 		section: 'General'
 	});
 
-	RocketChat.settings.add('Assitify_Deactivate_request_closing_comments', false, {
+	RocketChat.settings.add('Assistify_Deactivate_request_closing_comments', false, {
 		group: 'Assistify',
 		i18nLabel: 'Deactivate_close_comment',
 		type: 'boolean',

--- a/packages/rocketchat-i18n/i18n/assistifyHelpRequest.de.i18n.yml
+++ b/packages/rocketchat-i18n/i18n/assistifyHelpRequest.de.i18n.yml
@@ -8,6 +8,7 @@ create-e: Thema anlegen
 create-r: Anfrage anlegen
 delete-e: Thema löschen
 delete-r: Anfrage löschen
+Deactivate_close_comment: Kommentieren beim Schließen von Anfragen verhindern
 Expertise_description: Ein Thema beschreibt ein Wissensgebiet. Experten beantworten hierzu Anfragen
 Expertise_does_not_exist: Das Thema gibt es nicht
 Expertise_explanation: Ein Thema beschreibt ein Wissensgebiet. Zu einem Thema können Anfragen erstellt werden, die von den Experten, die dem Thema als Mitglieder zugeordnet sind, beantwortet werden können.

--- a/packages/rocketchat-i18n/i18n/assistifyHelpRequest.en.i18n.yml
+++ b/packages/rocketchat-i18n/i18n/assistifyHelpRequest.en.i18n.yml
@@ -1,5 +1,5 @@
 application: Application
-Assitify_room_count: Roomcount
+Assistify_room_count: Roomcount
 Choose_experts: Choose experts
 Close_HelpRequest: Close chat
 Close_request_comment: You can add (famous) last words

--- a/packages/rocketchat-i18n/i18n/assistifyHelpRequest.en.i18n.yml
+++ b/packages/rocketchat-i18n/i18n/assistifyHelpRequest.en.i18n.yml
@@ -1,10 +1,10 @@
 application: Application
-Asssitify_room_count: Roomcount
+Assitify_room_count: Roomcount
 Choose_experts: Choose experts
 Close_HelpRequest: Close chat
 Close_request_comment: You can add (famous) last words
 Close_request_warning: Please do close the request once you are finished answering the questions asked. This way, we can learn from what you have written.
-Deactivate_close_comment: Allow Request closing comment
+Deactivate_close_comment: Don't allow closing comments
 Expertise_description: A topic is an area of knowledge with known experts.
 Expertise_does_not_exist: Expertise does not exist
 Expertise_explanation: A topic is an area of knowledge. Experts join a topic in order to help others solve their question in that area.

--- a/packages/rocketchat-i18n/i18n/assistifyHelpRequest.en.i18n.yml
+++ b/packages/rocketchat-i18n/i18n/assistifyHelpRequest.en.i18n.yml
@@ -4,6 +4,7 @@ Choose_experts: Choose experts
 Close_HelpRequest: Close chat
 Close_request_comment: You can add (famous) last words
 Close_request_warning: Please do close the request once you are finished answering the questions asked. This way, we can learn from what you have written.
+Deactivate_close_comment: Allow Request closing comment
 Expertise_description: A topic is an area of knowledge with known experts.
 Expertise_does_not_exist: Expertise does not exist
 Expertise_explanation: A topic is an area of knowledge. Experts join a topic in order to help others solve their question in that area.


### PR DESCRIPTION
Features [Deactivation of Closing comment](https://github.com/assistify/Rocket.Chat/issues/24) solution. This closes issue no: #24 

Thus, Please check if the solution and the code is optimistic.

**Solution Overview**
- New permission setting so called `Assitify_Deactivate_request_closing_comments` grouped under `Assitify` is created. 
- Comments section in the Sweet alert window is dynamically determined based on the above setting.
- The new setting has reflected in the `setting-based-permission` section with no implications found while testing together.
