### PR TITLE
Copy notifications from topic only for experts

### DIFF
--- a/packages/assistify-help-request/server/methods/createRequest.js
+++ b/packages/assistify-help-request/server/methods/createRequest.js
@@ -1,4 +1,3 @@
-
 Meteor.methods({
 	createRequest(name, expertise = '', openingQuestion, members = [], environment) {
 		const requestTitle = name;
@@ -47,10 +46,12 @@ Meteor.methods({
 
 				if (expertise) {
 					const expertiseSubscription = RocketChat.models.Subscriptions.findOneByRoomIdAndUserId(expertise._id, user._id);
-					RocketChat.models.Subscriptions.updateDesktopNotificationsById(subscription._id, expertiseSubscription.desktopNotifications);
-					RocketChat.models.Subscriptions.updateMobilePushNotificationsById(subscription._id, expertiseSubscription.mobilePushNotifications);
-					RocketChat.models.Subscriptions.updateEmailNotificationsById(subscription._id, expertiseSubscription.emailNotifications);
-					RocketChat.models.Subscriptions.updateAudioNotificationsById(subscription._id, expertiseSubscription.audioNotifications);
+					if (expertiseSubscription) {
+						RocketChat.models.Subscriptions.updateDesktopNotificationsById(subscription._id, expertiseSubscription.desktopNotifications);
+						RocketChat.models.Subscriptions.updateMobilePushNotificationsById(subscription._id, expertiseSubscription.mobilePushNotifications);
+						RocketChat.models.Subscriptions.updateEmailNotificationsById(subscription._id, expertiseSubscription.emailNotifications);
+						RocketChat.models.Subscriptions.updateAudioNotificationsById(subscription._id, expertiseSubscription.audioNotifications);
+					}
 				} else {
 					// Fallback: notify everything
 					RocketChat.models.Subscriptions.updateDesktopNotificationsById(subscription._id, 'all');
@@ -81,13 +82,13 @@ Meteor.methods({
 		}
 		const roomCreateResult = RocketChat.createRoom('r', name, Meteor.user() && Meteor.user().username, members, false, {expertise});
 		if (requestTitle) {
-			RocketChat.saveRoomTopic (roomCreateResult.rid, expertise, Meteor.user());
+			RocketChat.saveRoomTopic(roomCreateResult.rid, expertise, Meteor.user());
 		}
 		createNotifications(roomCreateResult.rid, members.concat([Meteor.user().username]));
 		const room = RocketChat.models.Rooms.findOneById(roomCreateResult.rid);
 		if (openingQuestion) {
 			const msg = openingQuestion;
-			const msgObject = { _id: Random.id(), rid:roomCreateResult.rid, msg};
+			const msgObject = {_id: Random.id(), rid: roomCreateResult.rid, msg};
 			RocketChat.sendMessage(Meteor.user(), msgObject, room);
 		}
 


### PR DESCRIPTION
Fixes #180

Since normal users don't have a subscription for the expert topic, there was an exception raised when trying to copy the notifications from the parent room.