### PR TITLE
Use encodeURI in AmazonS3 contentDisposition file.name to prevent fail

### DIFF
--- a/packages/rocketchat-file-upload/ufs/AmazonS3/server.js
+++ b/packages/rocketchat-file-upload/ufs/AmazonS3/server.js
@@ -138,7 +138,7 @@ export class AmazonS3Store extends UploadFS.Store {
 				Key: this.getPath(file),
 				Body: writeStream,
 				ContentType: file.type,
-				ContentDisposition: `inline; filename="${ file.name }"`
+				ContentDisposition: `inline; filename="${ encodeURI(file.name) }"`
 
 			}, (error) => {
 				if (error) {


### PR DESCRIPTION
This PR fixes the upload to S3 failing with special characters in filenames (such as German Umlaute, ä, ö, ü).
Cheery-picked a fix from 0.60