### PR TITLE
[PORT] Fix "close by visitor"

### DIFF
--- a/packages/rocketchat-livechat/server/methods/closeByVisitor.js
+++ b/packages/rocketchat-livechat/server/methods/closeByVisitor.js
@@ -13,6 +13,7 @@ Meteor.methods({
 		const language = (visitor && visitor.language) || RocketChat.settings.get('language') || 'en';
 
 		return RocketChat.Livechat.closeRoom({
+			user: Meteor.user(),
 			visitor,
 			room,
 			comment: TAPi18n.__('Closed_by_visitor', { lng: language })


### PR DESCRIPTION
This is a port of https://github.com/RocketChat/Rocket.Chat/pull/9698 .
While this is syntactically correct now (and the visitor can close the livechat properly), it is not yet confirmed that the user submitted as the one who closed is set properly.
However, this can be merged imho nevertheless.

@janrudolph please test manually and - if applicable - check the statistics.