### PR TITLE
Provide more information for outgoing integrations

### DIFF
--- a/packages/rocketchat-integrations/server/lib/triggerHandler.js
+++ b/packages/rocketchat-integrations/server/lib/triggerHandler.js
@@ -384,6 +384,8 @@ RocketChat.integrations.triggerHandler = new class RocketChatIntegrationHandler 
 				data.user_id = message.u._id;
 				data.user_name = message.u.username;
 				data.text = message.msg;
+				data.room = room;
+				data.siteUrl = RocketChat.settings.get('Site_Url');
 
 				if (message.alias) {
 					data.alias = message.alias;


### PR DESCRIPTION
This change allows outgoing integrations to access the room object as a whole.
This harmonizes the information available to other events for outgoing integrations (where the room was already available).
It's been added in a compatible way, same as the SiteURL, which allows to navigate to a channel in case of cross-Rocket.Chat integrations.