### PR TITLE
[FIX] Properly handle 404-responses from the legacy/rocket.chat service

### DIFF
--- a/packages/assistify-ai/server/SmartiProxy.js
+++ b/packages/assistify-ai/server/SmartiProxy.js
@@ -55,7 +55,7 @@ export class SmartiProxy {
 				}
 			}
 
-			SystemLogger.error('Could not complete', method, 'to', url);
+			SystemLogger.error('Could not complete', method, 'to', url, error.response);
 			SystemLogger.debug(error);
 		}
 	}

--- a/packages/assistify-ai/server/lib/SmartiAdapter.js
+++ b/packages/assistify-ai/server/lib/SmartiAdapter.js
@@ -73,8 +73,7 @@ export class SmartiAdapter {
 		} else {
 			SystemLogger.debug('Smarti - Trying legacy service to retrieve conversation ID...');
 			const conversation = SmartiProxy.propagateToSmarti(verbs.get,
-				`legacy/rocket.chat?channel_id=${ message.rid }`, null,
-				function (error) {
+				`legacy/rocket.chat?channel_id=${ message.rid }`, null, (error) => {
 					// 404 is expected if no mapping exists
 					if (error.response.statusCode === 404) {
 						return null;

--- a/packages/assistify-ai/server/methods/SmartiWidgetBackend.js
+++ b/packages/assistify-ai/server/methods/SmartiWidgetBackend.js
@@ -7,7 +7,7 @@ const querystring = require('querystring');
 /** @namespace RocketChat.RateLimiter.limitFunction */
 
 /**
- * The SmartiWidgetBackend handles all interactions  triggered by the Smarti widget (not by Rocket.Chat hooks).
+ * The SmartiWidgetBackend handles all interactions triggered by the Smarti widget (not by Rocket.Chat hooks).
  * These 'Meteor.methods' are made available to be accessed via DDP, to be used in the Smarti widget.
  */
 Meteor.methods({
@@ -33,11 +33,11 @@ Meteor.methods({
 					}
 				}
 			)(verbs.get, `legacy/rocket.chat?channel_id=${ channelId }`, null, (error) => {
-        // 404 is expected if no mapping exists
-        if (error.response.statusCode === 404) {
-          return null;
-        }
-      });
+				// 404 is expected if no mapping exists
+				if (error.response.statusCode === 404) {
+					return null;
+				}
+			});
 
 			if (conversation && conversation.id) {
 				let timestamp = conversation.messages &&

--- a/packages/assistify-ai/server/methods/SmartiWidgetBackend.js
+++ b/packages/assistify-ai/server/methods/SmartiWidgetBackend.js
@@ -32,7 +32,12 @@ Meteor.methods({
 						return !RocketChat.authz.hasPermission(userId, 'send-many-messages');
 					}
 				}
-			)(verbs.get, `legacy/rocket.chat?channel_id=${ channelId }`);
+			)(verbs.get, `legacy/rocket.chat?channel_id=${ channelId }`, null, (error) => {
+        // 404 is expected if no mapping exists
+        if (error.response.statusCode === 404) {
+          return null;
+        }
+      });
 
 			if (conversation && conversation.id) {
 				let timestamp = conversation.messages &&


### PR DESCRIPTION
Non `2xx`/`3xx` are logged by default in the `SmartiProxy` module - but for the `legacy/rocket.chat` service, a `404` is sometimes the expected result.

Added custom error-handler for those calls to avoid log-cluttering (closes #236)