### PR TITLE
add a script to continue testing from the point where it crashed

### DIFF
--- a/.scripts/continueTesting.sh
+++ b/.scripts/continueTesting.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+tmpPath=tests/end-to-end/temporary_staged_test
+stopfile=`find ${tmpPath} -type f | head -1`
+echo 'Last stop at:' $stopfile
+[ -z "$retry_test" ] && retry_test=1
+stopfile=`find ${tmpPath} -type f | head -1`
+array=(`find tests/end-to-end/*/*.js -type f`)
+
+for j in ${!array[@]}; do
+  file=${array[$j]}
+  [[ ${stopfile##*/} == ${file##*/} ]] && [[ $stopfile != $file ]] && break
+done
+
+rm -rf $tmpPath
+mkdir -p $tmpPath
+for file in ${array[@]:$j}; do
+  failed=1
+  for i in `seq 1 $retry_test`; do
+    echo '-------------- '$i' try ---------------'
+    set -x
+    cp $file $tmpPath
+    CHIMP_PATH=$tmpPath meteor npm run chimp-path
+    failed=$?
+    set +x
+    if [ $failed -eq 0 ]; then
+      break
+    fi
+  done
+  if [ $failed -ne 0 ]; then
+    exit 1
+  fi
+  rm $tmpPath/${file##*/}
+done


### PR DESCRIPTION
To make testing more easy, I created a script that will continue testing where the last test failed when using the separateTesting.sh script.

## Steps to run tests:
`.scripts/separateTesting.sh`
After the test failed:
`.scripts/continueTesting.sh`