### PR TITLE
Fix Smarti-Adapter for livechats

### DIFF
--- a/packages/assistify-ai/server/lib/SmartiAdapter.js
+++ b/packages/assistify-ai/server/lib/SmartiAdapter.js
@@ -103,7 +103,7 @@ export class SmartiAdapter {
 					'channel_id': [message.rid]
 				},
 				'user': {
-					'id': room.u._id
+					'id': room.u ? room.u._id : room.v._id //different properties capture the owner in livechat- and other rooms
 				},
 				'messages': [requestBodyMessage],
 				'context': {


### PR DESCRIPTION
Livechat store the owner in a different property (`.v` vs. `.u` in all other room types)
Closes #262 
