### PR TITLE
Allow managers to add users to joined rooms

### DIFF
--- a/packages/assistify-defaults/server/roles.js
+++ b/packages/assistify-defaults/server/roles.js
@@ -210,6 +210,7 @@ const createManagerRole = function() {
 
 	const permissions = [
 		'add-user-to-any-c-room',
+		'add-user-to-joined-room',
 		'archive-room',
 		'ban-user',
 		'bulk-register-user',


### PR DESCRIPTION
Managers are already are allowed to add users to public rooms and to assign the moderator and owner-roles.
While this effectively grants them the ability to add a user to a private group they are members of, they couldn't join others directly.
This fixes this discomfort.