### PR TITLE
Prevent non-admins removing admin-role

### DIFF
--- a/packages/rocketchat-lib/server/functions/saveUser.js
+++ b/packages/rocketchat-lib/server/functions/saveUser.js
@@ -13,6 +13,13 @@ RocketChat.saveUser = function(userId, userData) {
 		});
 	}
 
+	if (RocketChat.authz.hasRole(userData._id, 'admin') && _.indexOf(userData.roles, 'admin') < 0 && !RocketChat.authz.hasRole(user._id, 'admin')) {
+		throw new Meteor.Error('error-action-not-allowed', 'Removing admin role is not allowed', {
+			method: 'insertOrUpdateUser',
+			action: 'Assign_admin'
+		});
+	}
+
 	if (!userData._id && !RocketChat.authz.hasPermission(userId, 'create-user')) {
 		throw new Meteor.Error('error-action-not-allowed', 'Adding user is not allowed', {
 			method: 'insertOrUpdateUser',
@@ -27,7 +34,7 @@ RocketChat.saveUser = function(userId, userData) {
 		});
 	}
 
-	if (userData.roles && _.indexOf(userData.roles, 'admin') >= 0 && !RocketChat.authz.hasPermission(userId, 'assign-admin-role')) {
+	if (userData.roles && _.indexOf(userData.roles, 'admin') >= 0 && !RocketChat.authz.hasRole('admin')) {
 		throw new Meteor.Error('error-action-not-allowed', 'Assigning admin is not allowed', {
 			method: 'insertOrUpdateUser',
 			action: 'Assign_admin'


### PR DESCRIPTION
closes issue #293 

We decided to ignore the `assign-admin-role` permission and only allow removing or adding the `admin-role` for `admin-users`

For some reasons the user-edit dialog does not use the meteor methods or functions from the `RocketChat.authorization` package instead has its own method to handle that case separately. Therefore it might be possible to change the `admin-role` without being admin but with `assign-admin-role` permission from other sections of the code (e.g. via api).