### PR TITLE
Fix livechat notifications for guest pool based routing

### DIFF
--- a/packages/rocketchat-lib/server/lib/sendNotificationsOnMessage.js
+++ b/packages/rocketchat-lib/server/lib/sendNotificationsOnMessage.js
@@ -63,7 +63,7 @@ function notifyDesktopUser(userId, user, message, room, duration) {
 	if (UI_Use_Real_Name) {
 		message.msg = replaceMentionedUsernamesWithFullNames(message.msg, message.mentions);
 	}
-	let title = UI_Use_Real_Name ? user.name : `@${ user.username }`;
+	let title = UI_Use_Real_Name && user.name ? user.name : `@${ user.username }`;
 	if (room.t !== 'd' && room.name) {
 		title += ` @ #${ room.name }`;
 	}
@@ -114,6 +114,27 @@ function messageContainsHighlight(message, highlights) {
 	});
 
 	return has;
+}
+
+/**
+ * Detects the agents to be notified.
+ * This is essential for guest pool routing configuration.
+ * We'll only notify online agents.
+ * If the configuration allows to leave a message even if offline, the agents returning
+ * to the online status have to check the queue manually - which should be good practice
+	//
+ * @param {*} room The livechat room
+ */
+function getLivechatAgentIdsForRoom(room) {
+	const inquiry = RocketChat.models.LivechatInquiry.findOneByRoomId(room._id);
+	const department = inquiry ? inquiry.department : null;
+	let agents = [];
+	if (department) {
+		agents = RocketChat.models.LivechatDepartmentAgents.getOnlineForDepartment(department).fetch();
+	} else {
+		agents = RocketChat.models.Users.findOnlineAgents().fetch();
+	}
+	return agents.map((agent)=>agent.agentId);
 }
 
 function getBadgeCount(userId) {
@@ -438,6 +459,15 @@ RocketChat.callbacks.add('afterSaveMessage', function(message, room, userId) {
 			userIdsForAudio = userIdsForAudio.concat(highlightsIds);
 			userIdsToNotify = userIdsToNotify.concat(highlightsIds);
 			userIdsToPushNotify = userIdsToPushNotify.concat(highlightsIds);
+		}
+
+		// for live chat rooms which are configured as guest pool, all agents
+		// of the targeted department need to be notified
+		if (room.t === 'l' && !room.servedBy) {
+			const agentIds = getLivechatAgentIdsForRoom(room);
+			userIdsForAudio = userIdsForAudio.concat(agentIds);
+			userIdsToNotify = userIdsToNotify.concat(agentIds);
+			userIdsToPushNotify = userIdsToPushNotify.concat(agentIds);
 		}
 
 		userIdsToNotify = _.without(_.compact(_.unique(userIdsToNotify)), message.u._id);

--- a/packages/rocketchat-livechat/server/models/LivechatInquiry.js
+++ b/packages/rocketchat-livechat/server/models/LivechatInquiry.js
@@ -7,8 +7,8 @@ class LivechatInquiry extends RocketChat.models._Base {
 		this.tryEnsureIndex({ 'message': 1 }); // message sent by the client
 		this.tryEnsureIndex({ 'ts': 1 }); // timestamp
 		this.tryEnsureIndex({ 'code': 1 }); // (for routing)
-		this.tryEnsureIndex({ 'agents': 1}); // Id's of the agents who can see the inquiry (handle departments)
-		this.tryEnsureIndex({ 'status': 1}); // 'open', 'taken'
+		this.tryEnsureIndex({ 'agents': 1 }); // Id's of the agents who can see the inquiry (handle departments)
+		this.tryEnsureIndex({ 'status': 1 }); // 'open', 'taken'
 	}
 
 	findOneById(inquiryId) {
@@ -58,7 +58,7 @@ class LivechatInquiry extends RocketChat.models._Base {
 	 * return the status of the inquiry (open or taken)
 	 */
 	getStatus(inquiryId) {
-		return this.findOne({'_id': inquiryId}).status;
+		return this.findOne({ '_id': inquiryId }).status;
 	}
 
 	updateVisitorStatus(token, status) {
@@ -74,6 +74,10 @@ class LivechatInquiry extends RocketChat.models._Base {
 		};
 
 		return this.update(query, update);
+	}
+
+	findOneByRoomId(roomId) {
+		return this.findOne({ rid: roomId });
 	}
 }
 


### PR DESCRIPTION
This fixes desktop notifications not being created if a live chat visitor created a room by sending the first message.

## How to test

- Configure a livechat with guest pool, add an agent.
- Create a new live chat and verify the desktop notification appears
- add two departments and configure an agent
- Create a new live chat selecting a department
- Send a new message and check the notification appears