### PR TITLE
fixed intial statistic creation

### DIFF
--- a/packages/rocketchat-statistics/server/functions/getUsages.js
+++ b/packages/rocketchat-statistics/server/functions/getUsages.js
@@ -6,7 +6,7 @@ export function getUsages() {
 	const userDB = RocketChat.models.Users;
 	const subDB = RocketChat.models.Subscriptions;
 	const messageDB = RocketChat.models.Messages;
-	const usages = {};
+	const usages = [];
 	const users = userDB.model.aggregate([
 		{
 			$unwind: '$emails'
@@ -107,7 +107,7 @@ export function getUsages() {
 		user._id = SHA256(user.emails.address);
 		delete user.emails.address;
 		delete user.emails;
-		usages[user._id] = user;
+		usages.push(user);
 
 	}
 	return usages;

--- a/packages/rocketchat-statistics/server/functions/getUsages.js
+++ b/packages/rocketchat-statistics/server/functions/getUsages.js
@@ -2,7 +2,7 @@
 
 export function getUsages() {
 	const lastStatistics = RocketChat.models.Statistics.findLast();
-	const lastStatisticsCreatedAt = lastStatistics ? lastStatistics.createdAt : 0;
+	const lastStatisticsCreatedAt = lastStatistics ? lastStatistics.createdAt : new Date();
 	const userDB = RocketChat.models.Users;
 	const subDB = RocketChat.models.Subscriptions;
 	const messageDB = RocketChat.models.Messages;


### PR DESCRIPTION
Hotfix for the first statistic.
`Exception in defer callback: TypeError: lastStatisticsCreatedAt.toISOString is not a function`
Fixed by initializing the first date with the current date instead of a 0.

**Side effects:**
When the first statistic gets created after users have written messages, this data is not in the usages section. But the time range stays the same with respect to the future statistics.