### PR TITLE
add threads as new room type t to statistic

### DIFF
--- a/packages/rocketchat-statistics/server/functions/getUsages.js
+++ b/packages/rocketchat-statistics/server/functions/getUsages.js
@@ -29,7 +29,7 @@ export function getUsages() {
 		{
 			$group:
 				{
-					_id: { uid: '$u._id', subType: '$t'},
+					_id: { uid: '$u._id', subType: {$cond: [{$not: ['$parentRoomId']}, '$t', 't']}},
 					subs: { $sum: 1 }
 				}
 		},
@@ -73,7 +73,7 @@ export function getUsages() {
 		{
 			$group:
 				{
-					_id: { uid: '$u._id', msgRoom: '$msgRooms.t'},
+					_id: { uid: '$u._id', msgRoom: {$cond: [{$not: ['$msgRooms.parentRoomId']}, '$msgRooms.t', 't']} },
 					messages: { $sum: 1 }
 				}
 		},

--- a/packages/rocketchat-statistics/server/functions/getUsages.js
+++ b/packages/rocketchat-statistics/server/functions/getUsages.js
@@ -28,8 +28,8 @@ export function getUsages() {
 		},
 		{
 			$group:
-				{
-					_id: { uid: '$u._id', subType: {$cond: [{$not: ['$parentRoomId']}, '$t', 't']}},
+				{ // if the room contains a parentRoomId it is actually a thread, therefor marked as roomtype 'thread'
+					_id: { uid: '$u._id', subType: {$cond: [{$not: ['$parentRoomId']}, '$t', 'thread']}},
 					subs: { $sum: 1 }
 				}
 		},
@@ -72,8 +72,8 @@ export function getUsages() {
 		},
 		{
 			$group:
-				{
-					_id: { uid: '$u._id', msgRoom: {$cond: [{$not: ['$msgRooms.parentRoomId']}, '$msgRooms.t', 't']} },
+				{ // if the room contains a parentRoomId it is actually a thread, therefor marked as roomtype 'thread'
+					_id: { uid: '$u._id', msgRoom: {$cond: [{$not: ['$msgRooms.parentRoomId']}, '$msgRooms.t', 'thread']} },
 					messages: { $sum: 1 }
 				}
 		},


### PR DESCRIPTION
Added threads as new room type 't' to statistics

Example with 1 new thread (1 message) and 1 new public channel (4 messages)
```
I20180907-11:27:13.814(2)? 2018-09-07T09:25:27.615Z
I20180907-11:27:13.815(2)? Map {
I20180907-11:27:13.815(2)?   'tqxzu8ANwZjQEL6x4' => [ { type: 'c', subscriptions: 1 },
I20180907-11:27:13.815(2)?   { type: 't', subscriptions: 1 } ] }
I20180907-11:27:13.817(2)? Map {
I20180907-11:27:13.818(2)?   'rocket.cat' => [ { type: 't', messages: 1 } ],
I20180907-11:27:13.818(2)?   'tqxzu8ANwZjQEL6x4' => [ { type: 'c', messages: 4 }, { type: 't', messages: 1 } ] }
```