### PR TITLE
removed unused setting properties

### DIFF
--- a/packages/assistify-configuration/server/config.js
+++ b/packages/assistify-configuration/server/config.js
@@ -5,4 +5,12 @@ Meteor.startup(() => {
 	if (!languageSetting.value && languageSetting.value === languageSetting.packageValue) {
 		RocketChat.models.Settings.db.updateValueById(languageSetting._id, 'en');
 	}
+
+	/* Remove this three lines after they have been executed once on the target environment */
+	RocketChat.models.Settings.db.removeById('Assistify_Show_Standard_Features');
+	RocketChat.models.Settings.db.removeById('Assistify_Bot_Username');
+	RocketChat.models.Settings.db.removeById('Assistify_Bot_Automated_Response_Threshold');
+	RocketChat.models.Settings.db.removeById('Assistify_room_count');
+	RocketChat.models.Settings.db.removeById('Experts_channel');
+	RocketChat.models.Settings.db.removeById('Deactivate_close_comment');
 });

--- a/packages/assistify-configuration/server/config.js
+++ b/packages/assistify-configuration/server/config.js
@@ -1,4 +1,4 @@
-/* globals RocketChat */
+/* globals RocketChat, SystemLogger */
 
 Meteor.startup(() => {
 	const languageSetting = RocketChat.models.Settings.db.findOneById('Language');
@@ -13,5 +13,4 @@ Meteor.startup(() => {
 	RocketChat.models.Settings.db.removeById('Assistify_room_count');
 	RocketChat.models.Settings.db.removeById('Experts_channel');
 	RocketChat.models.Settings.db.removeById('Deactivate_close_comment');
-	RocketChat.models.Settings.db.removeById('Agent_typing_alias');
 });

--- a/packages/assistify-configuration/server/config.js
+++ b/packages/assistify-configuration/server/config.js
@@ -13,4 +13,5 @@ Meteor.startup(() => {
 	RocketChat.models.Settings.db.removeById('Assistify_room_count');
 	RocketChat.models.Settings.db.removeById('Experts_channel');
 	RocketChat.models.Settings.db.removeById('Deactivate_close_comment');
+	RocketChat.models.Settings.db.removeById('Agent_typing_alias');
 });

--- a/packages/assistify-configuration/server/config.js
+++ b/packages/assistify-configuration/server/config.js
@@ -1,4 +1,4 @@
-/* globals RocketChat, SystemLogger */
+/* globals RocketChat */
 
 Meteor.startup(() => {
 	const languageSetting = RocketChat.models.Settings.db.findOneById('Language');


### PR DESCRIPTION
closes #490

I was not able to validate that the removal worked within `packages/assistify-ai/server/migrations.js`

Since this removal is only temporary and removing those lines afterwards is required anyway, I think it's OK as well to place it in  `packages/assistify-configuration/server/config.js`

@mrsimpson If you know some better place, feel free.