### PR TITLE
[Livechat] Notify agents when a new chat is queued

### DIFF
--- a/packages/rocketchat-lib/server/lib/index.js
+++ b/packages/rocketchat-lib/server/lib/index.js
@@ -7,9 +7,11 @@
 */
 
 import { RoomSettingsEnum, RoomTypeConfig, RoomTypeRouteConfig } from '../../lib/RoomTypeConfig';
+import { sendNotification } from './sendNotificationsOnMessage.js';
 
 export {
 	RoomSettingsEnum,
 	RoomTypeConfig,
-	RoomTypeRouteConfig
+	RoomTypeRouteConfig,
+	sendNotification
 };

--- a/packages/rocketchat-lib/server/lib/sendNotificationsOnMessage.js
+++ b/packages/rocketchat-lib/server/lib/sendNotificationsOnMessage.js
@@ -260,3 +260,5 @@ function sendAllNotifications(message, room) {
 }
 
 RocketChat.callbacks.add('afterSaveMessage', sendAllNotifications, RocketChat.callbacks.priority.LOW, 'sendNotificationsOnMessage');
+
+export {sendNotification};

--- a/packages/rocketchat-livechat/.app/i18n/de.i18n.json
+++ b/packages/rocketchat-livechat/.app/i18n/de.i18n.json
@@ -16,6 +16,7 @@
   "How_satisfied_were_you_with_this_chat": "Wie zufrieden sind Sie mit diesem Gespräch?",
   "Installation": "Installation",
   "New_messages": "Neue Nachrichten",
+  "New_livechat_in_queue": "Neuer Chat in der Wartschlange",
   "No": "Nein",
   "Options": "Optionen",
   "Please_answer_survey": "Bitte nehmen Sie sich einen Moment Zeit, um kurz einige Fragen zu dem Gespräch zu beantworten.",

--- a/packages/rocketchat-livechat/.app/i18n/en.i18n.json
+++ b/packages/rocketchat-livechat/.app/i18n/en.i18n.json
@@ -16,6 +16,7 @@
   "How_satisfied_were_you_with_this_chat": "How satisfied were you with this chat?",
   "Installation": "Installation",
   "New_messages": "New messages",
+  "New_livechat_in_queue": "New chat in queue",
   "No": "No",
   "Options": "Options",
   "Please_answer_survey": "Please take a moment to answer a quick survey about this chat",

--- a/packages/rocketchat-livechat/server/lib/QueueMethods.js
+++ b/packages/rocketchat-livechat/server/lib/QueueMethods.js
@@ -1,4 +1,5 @@
 import _ from 'underscore';
+import {sendNotification} from 'meteor/rocketchat:lib';
 
 RocketChat.QueueMethods = {
 	/* Least Amount Queuing method:
@@ -141,6 +142,26 @@ RocketChat.QueueMethods = {
 		RocketChat.models.LivechatInquiry.insert(inquiry);
 		RocketChat.models.Rooms.insert(room);
 
+		// Alert the agents of the queued request
+		agentIds.forEach((agentId) => {
+			sendNotification({
+				//fake a subscription in order to make use of the function defined above
+				subscription: {
+					rid: room._id,
+					t : room.t,
+					u: {
+						_id : agentId
+					}
+				},
+				sender: room.v,
+				hasMentionToAll: true, //consider all agents to be in the room
+				hasMentionToHere: false,
+				message: Object.assign(message, {u: room.v}),
+				notificationMessage: message.msg,
+				room: Object.assign(room, {name: TAPi18n.__('New_livechat_in_queue')}),
+				mentionIds: []
+			});
+		});
 		return room;
 	},
 	'External'(guest, message, roomInfo, agent) {


### PR DESCRIPTION
This PR adds a notification once a livechat guest arrives in a queue.
In contrast to previous behavior, this creates the notification only once, not for all messages.
After the chat has been taken by an agent, of course the notifications are effective as usual