### PR TITLE
Hide system messages in threads

### DIFF
--- a/packages/assistify-threading/server/methods/createThread.js
+++ b/packages/assistify-threading/server/methods/createThread.js
@@ -177,6 +177,7 @@ export class ThreadBuilder {
 			// Create messages linking the parent room and the thread
 			this._linkMessages(threadRoom, this._parentRoom, repostedMessage);
 		}
+		Meteor.call('saveRoomSettings', threadRoomCreationResult.rid, 'systemMessages', false);
 
 		return threadRoom;
 	}


### PR DESCRIPTION
Workaround for https://github.com/assistify/Rocket.Chat/issues/507 
We hide all system messages in the threads, so users can still leave the room but no message is shown.
The original question message is still shown.
![2018-09-17 13 31 53](https://user-images.githubusercontent.com/11913979/45620738-29849300-ba7e-11e8-8487-0b7a4b4cf128.gif)
