### PR TITLE
[Livechat] Fix agent joining on pick from guestpool

### DIFF
--- a/packages/rocketchat-livechat/.app/client/lib/_livechat.js
+++ b/packages/rocketchat-livechat/.app/client/lib/_livechat.js
@@ -49,7 +49,7 @@ this.Livechat = new (class Livechat {
 						this._agent.set(result);
 					}
 				});
-				this.stream.on(this._room.get(), { visitorToken: visitor.getToken() }, (eventData) => {
+				this.stream.on(this._room.get(), { token: visitor.getToken() }, (eventData) => {
 					if (!eventData || !eventData.type) {
 						return;
 					}


### PR DESCRIPTION
This fixes the agent being properly notified to the livechat widget when joined to the room.
Earlier on, the agent's full  also avatar were not shown unless the page was refreshed actively by the guest.

Now, it works as expected: Once the agent picks the inquiry, he's immediately visible for the guest.
