### PR TITLE
[Threading] Configure limit of max invited users

### DIFF
--- a/packages/assistify-threading/config.js
+++ b/packages/assistify-threading/config.js
@@ -37,6 +37,14 @@ Meteor.startup(() => {
 		RocketChat.models.Settings.updateValueById('Thread_default_parent_Channel', defaultChannel);
 	}
 
+	RocketChat.settings.add('Thread_invitations_threshold', 10, {
+		group: 'Threading',
+		i18nLabel: 'Thread_invitations_threshold',
+		i18nDescription: 'Thread_invitations_threshold_description',
+		type: 'int',
+		public: true
+	});
+
 	RocketChat.settings.add('Thread_from_context_menu', 'button', {
 		group: 'Threading',
 		i18nLabel: 'Thread_from_context_menu',

--- a/packages/assistify-threading/server/methods/createThread.js
+++ b/packages/assistify-threading/server/methods/createThread.js
@@ -121,6 +121,7 @@ export class ThreadBuilder {
 
 	_getMembers() {
 		const checkRoles = ['owner', 'moderator', 'leader'];
+		const maxInvitationCount = Math.max(RocketChat.models.Settings.findOneById('Thread_invitations_threshold').value, 0) || 0;
 		let members = [];
 		const admins = RocketChat.models.Subscriptions.findByRoomIdAndRoles(this._parentRoomId, checkRoles).fetch().map(s => {
 			return {
@@ -131,6 +132,10 @@ export class ThreadBuilder {
 			fields: {
 				'u._id': 1,
 				'u.username': 1
+			},
+			sort: {
+				open: -1,
+				ls: -1
 			}
 		}).fetch().map(s => {
 			return {
@@ -140,7 +145,7 @@ export class ThreadBuilder {
 		});
 		if (this._parentRoom.t === 'c') {
 			// only add online users
-			members = RocketChat.models.Users.findUsersWithUsernameByIdsNotOffline(users.map(user=>user.id)).fetch().map(user=>user.username);
+			members = RocketChat.models.Users.findUsersWithUsernameByIdsNotOffline(users.slice(0, maxInvitationCount).map(user=>user.id)).fetch().map(user=>user.username);
 			// add admins to the member list and avoid duplicates
 			members = Array.from(new Set(members.concat(admins.map(user=>user.username))));
 		} else {

--- a/packages/rocketchat-i18n/i18n/de.i18n.json
+++ b/packages/rocketchat-i18n/i18n/de.i18n.json
@@ -2527,6 +2527,8 @@
   "thread-welcome" : "Danke __username__, dass Du einen neuen Thread angelegt hast! Ich habe für Dich Mitglieder aus __parentChannel__ eingeladen. Tipp: mit \"@all\" kannst Du sie anstupsen, wenn sich länger niemand melden sollte ;)",
   "Threading_description": "Erstelle einen Thread, um wichtigen Dingen mehr Raum zu geben. Dort kannst Du mit allen verfügbaren Mitgliedern schreiben, ohne andere zu stören. So sorgst Du für etwas mehr Ordnung in Eurem Chat.",
   "Thread_from_context_menu": "Threads im Kontext-Menü",
+  "Thread_invitations_threshold": "Max. Anzahl automatisch einzuladender Benutzer",
+  "Thread_invitations_threshold_description": "Max. Anzahl der Benutzer, die automatisch zu einem öffentlichen Thread hinzugezogen werden",
   "Threading_context_menu_button": "Separater Button",
   "Threading_context_menu_none": "Unsichtbar",
   "Thread_creation_on_home": "Threads von der Home-Seite aus anlegen",

--- a/packages/rocketchat-i18n/i18n/en.i18n.json
+++ b/packages/rocketchat-i18n/i18n/en.i18n.json
@@ -2514,6 +2514,8 @@
   "thread-created" : "I started a new __channelLink__",
   "thread-welcome" : "Thanks __username__ for creating a thread! I invited some members from __parentChannel__ who shall be able to help you. Hint: You can poke them with \"@all\", in case there's nothing happening for a longer time ;)",
   "Thread_from_context_menu": "Threads in context-menu",
+  "Thread_invitations_threshold": "Max. users to be automatically invited",
+  "Thread_invitations_threshold_description": "Max. count of users who are automatically being invited into a public thread",
   "Threading_context_menu_button": "Dedicated button",
   "Threading_context_menu_none": "Invisible",
   "Threading_description": "Help keeping an overview about what's going on! By creating a thread, a sub-channel of the one you selected is created and both are linked.",


### PR DESCRIPTION
## What this brings

This PR add a option to configure how many users shall be invited to public channels.

## Motivation

In large public channels (particularly the general channel), many many users might be invited - and disturbed in their work. A limit of the users to be invited reduces this pain. 
By how it's been implemented, it also gives users the opportunity to be less likely invited.

## Implementation

Until we've got a full-fledged NLP with expertise-analysis up and running, we'll have to determine expertship in a particular channel differently.
I decided that online users, who are *actively following the channel* (have not hidden or left it) and *who have most recently visited the channel* are likely to be the ones to answer questions asked in threads.

## Caveats

- All other users who are not automatically invited will still see the thread-message and will be able to join the discussion. 
- By setting a threshold of 0, no users except the moderators, leaders and owners will be added.