### PR TITLE
SAML-registration: get rid of null-names

### DIFF
--- a/packages/assistify-migrations/server/startup/migrations.js
+++ b/packages/assistify-migrations/server/startup/migrations.js
@@ -5,82 +5,18 @@ on startup which migrate data - ignoring the actual version
  */
 
 Meteor.startup(() => {
-	const topics = RocketChat.models.Rooms.findByType('e').fetch();
-	let counterRequests = 0;
-	// Update room type and parent room id for request
 
-	const mapRoomParentRoom = new Map();
-	RocketChat.models.Rooms.findByType('r').forEach((request) => {
-		const update = {};
-		update.$set = {};
-		let parentTopic = null;
+	const _guessNameFromUsername = function(username) {
+		return username
+			.replace(/\W/g, ' ')
+			.replace(/\s(.)/g, function($1) { return $1.toUpperCase(); })
+			.replace(/^(.)/, function($1) { return $1.toLowerCase(); })
+			.replace(/^\w/, function($1) { return $1.toUpperCase(); });
+	};
 
-		if (request.expertise) {
-			parentTopic = topics.find(topic => {
-				return request.expertise === topic.name;
-			});
-			if (!parentTopic) {
-				console.log('couldn\'t find topic', request.expertise, '- ignoring');
-			} else {
-				update.$set.parentRoomId = parentTopic._id;
-				mapRoomParentRoom.set(request._id, parentTopic._id); // buffer the mapping for the subscriptions update lateron
-			}
-		}
-		update.$set.oldType = request.t;
-		update.$set.t = 'p';
-		// update requests
-		RocketChat.models.Rooms.update({_id: request._id}, update);
-		counterRequests++;
-	});
-	console.log('Migrated', counterRequests, 'requests to private groups');
-
-	//Update room type and parent room id for expertises
-	RocketChat.models.Rooms.update({
-		t: 'e'
-	}, {
-		$set: {
-			oldType: 'e', // move the room type as old room type
-			t: 'c' // set new room type to public channel
-		}
-	}, {
-		multi: true
-	});
-
-	//update subscriptions for requests
-	RocketChat.models.Subscriptions.update({
-		t: 'r'
-	}, {
-		$set: {
-			oldType: 'r',
-			t: 'p'
-		}
-	}, {
-		multi: true
-	});
-
-	// provide parent Room links in the subscriptions as well
-	mapRoomParentRoom.forEach((value, key)=>{
-		RocketChat.models.Subscriptions.update({
-			rid: key
-		}, {
-			$set: {
-				parentRoomId: value
-			}
-		}, {
-			multi: true
-		});
-	});
-
-	//update subscriptions for expertises
-	RocketChat.models.Subscriptions.update({
-		t: 'e'
-	}, {
-		$set: {
-			oldType: 'e',
-			t: 'c'
-		}
-	}, {
-		multi: true
+	const usersWithoutName = RocketChat.models.Users.find({name: null}).fetch();
+	usersWithoutName.forEach((user)=>{
+		RocketChat.models.Users.update({_id: user._id}, {$set: {name: _guessNameFromUsername(user.username)}});
 	});
 
 });

--- a/packages/meteor-accounts-saml/saml_server.js
+++ b/packages/meteor-accounts-saml/saml_server.js
@@ -86,6 +86,15 @@ Meteor.methods({
 });
 
 Accounts.registerLoginHandler(function(loginRequest) {
+
+	const _guessNameFromUsername = function(username) {
+		return username
+			.replace(/\W/g, ' ')
+			.replace(/\s(.)/g, function($1) { return $1.toUpperCase(); })
+			.replace(/^(.)/, function($1) { return $1.toLowerCase(); })
+			.replace(/^\w/, function($1) { return $1.toUpperCase(); });
+	};
+
 	if (!loginRequest.saml || !loginRequest.credentialToken) {
 		return undefined;
 	}
@@ -131,7 +140,7 @@ Accounts.registerLoginHandler(function(loginRequest) {
 				newUser.username = loginResult.profile.username;
 			}
 
-			newUser.name = newUser.name || newUser.username; // Make sure every user has a name as well
+			newUser.name = newUser.name || _guessNameFromUsername(newUser.username); // Make sure every user has a name as well
 
 			const userId = Accounts.insertUserDoc({}, newUser);
 			user = Meteor.users.findOne(userId);

--- a/packages/meteor-accounts-saml/saml_server.js
+++ b/packages/meteor-accounts-saml/saml_server.js
@@ -131,6 +131,8 @@ Accounts.registerLoginHandler(function(loginRequest) {
 				newUser.username = loginResult.profile.username;
 			}
 
+			newUser.name = newUser.name || newUser.username; // Make sure every user has a name as well
+
 			const userId = Accounts.insertUserDoc({}, newUser);
 			user = Meteor.users.findOne(userId);
 		}


### PR DESCRIPTION
## What this fixes

As users register using a SAML-provider, they got a username but no full name.

## How this is done

- A full name is guessed from the SAML ID (Replacing symbols with whitespace, uppercasing each word).
- A migration has been added.