### PR TITLE
Allow user with "bulk-register-user" permission to send invitation mails

### DIFF
--- a/packages/rocketchat-lib/server/methods/sendInvitationEmail.js
+++ b/packages/rocketchat-lib/server/methods/sendInvitationEmail.js
@@ -8,7 +8,7 @@ Meteor.methods({
 				method: 'sendInvitationEmail'
 			});
 		}
-		if (!RocketChat.authz.hasRole(Meteor.userId(), 'admin')) {
+		if (!RocketChat.authz.hasPermission(Meteor.userId(), 'bulk-register-user')) {
 			throw new Meteor.Error('error-not-allowed', 'Not allowed', {
 				method: 'sendInvitationEmail'
 			});

--- a/packages/rocketchat-ui-admin/client/users/adminInviteUser.html
+++ b/packages/rocketchat-ui-admin/client/users/adminInviteUser.html
@@ -1,5 +1,5 @@
 <template name="adminInviteUser">
-	{{#if isAdmin}}
+	{{#if isAllowed}}
 		<div class="content">
 			<div class="user-view">
 				<div class="about clearfix">

--- a/packages/rocketchat-ui-admin/client/users/adminInviteUser.js
+++ b/packages/rocketchat-ui-admin/client/users/adminInviteUser.js
@@ -2,8 +2,8 @@ import _ from 'underscore';
 import toastr from 'toastr';
 
 Template.adminInviteUser.helpers({
-	isAdmin() {
-		return RocketChat.authz.hasRole(Meteor.userId(), 'admin');
+	isAllowed() {
+		return RocketChat.authz.hasAtLeastOnePermission('bulk-register-user');
 	},
 	inviteEmails() {
 		return Template.instance().inviteEmails.get();


### PR DESCRIPTION
## What this fixes

When allowing a user to send invitation mails (permission `bulk-register-users`), a user who already had the permission to view administration and manage users could still not send the invitation emails

## How it's been implemented

The authorization `bulk-register-users` was not checked earlier, but whether the user has the `admin` role.
Since `bulk-register-users` is assigned to `admin` by default, the permission can safely be used without data migration.