### PR TITLE
SmartiProxy: Use params option instead building HTTP query strings

### DIFF
--- a/packages/assistify-ai/server/SmartiProxy.js
+++ b/packages/assistify-ai/server/SmartiProxy.js
@@ -28,8 +28,8 @@ export class SmartiProxy {
 	 *
 	 * @param {String} method - the HTTP method to use
 	 * @param {String} path - the path to call
-	 * @param {Object} [body=null] - the payload to pass (optional)
-	 * @param {String} [parameters=null] - the http query params (optional)
+	 * @param {Object} [parameters=null] - the http query params (optional)
+	 * @param {String} [body=null] - the payload to pass (optional)
 	 * @param {Function} onError=null - custom error handler
 	 *
 	 * @returns {Object}

--- a/packages/assistify-ai/server/SmartiProxy.js
+++ b/packages/assistify-ai/server/SmartiProxy.js
@@ -29,11 +29,12 @@ export class SmartiProxy {
 	 * @param {String} method - the HTTP method to use
 	 * @param {String} path - the path to call
 	 * @param {Object} [body=null] - the payload to pass (optional)
+	 * @param {String} [parameters=null] - the http query params (optional)
 	 * @param {Function} onError=null - custom error handler
 	 *
 	 * @returns {Object}
 	 */
-	static propagateToSmarti(method, path, body = null, onError = null) {
+	static propagateToSmarti(method, path, parameters = null, body = null, onError = null) {
 		const url = `${ SmartiProxy.smartiUrl }${ path }`;
 		const header = {
 			'X-Auth-Token': SmartiProxy.smartiAuthToken,
@@ -41,7 +42,11 @@ export class SmartiProxy {
 		};
 		try {
 			SystemLogger.debug('Sending request to Smarti', method, 'to', url, 'body', JSON.stringify(body));
-			const response = HTTP.call(method, url, {data: body, headers: header});
+			const response = HTTP.call(method, url, {
+				params: parameters,
+				data: body,
+				headers: header
+			});
 			if (response.statusCode < 400) {
 				return response.data || response.content; //.data if it's a json-response
 			} else {

--- a/packages/assistify-ai/server/methods/SmartiWidgetBackend.js
+++ b/packages/assistify-ai/server/methods/SmartiWidgetBackend.js
@@ -3,8 +3,6 @@ import {SystemLogger} from 'meteor/rocketchat:logger';
 import {SmartiProxy, verbs} from '../SmartiProxy';
 import {SmartiAdapter} from '../lib/SmartiAdapter';
 
-const querystring = require('querystring');
-
 /** @namespace RocketChat.RateLimiter.limitFunction */
 
 /**
@@ -91,8 +89,6 @@ Meteor.methods({
 		fq = fq ? { fq: `meta_channel_id:(${ fq })` } : { fq: 'meta_channel_id:""'}; //fallback: if the user's not authorized to view any room, filter for "nothing"
 		const params = Object.assign(queryParams, fq);
 
-		const queryString = querystring.stringify(queryParams);
-		SystemLogger.debug('QueryString: ', queryString);
 		const searchResult = RocketChat.RateLimiter.limitFunction(
 			SmartiProxy.propagateToSmarti, 5, 1000, {
 				userId(userId) {

--- a/packages/assistify-ai/server/methods/SmartiWidgetBackend.js
+++ b/packages/assistify-ai/server/methods/SmartiWidgetBackend.js
@@ -44,7 +44,7 @@ Meteor.methods({
 					return !RocketChat.authz.hasPermission(userId, 'send-many-messages');
 				}
 			}
-		)(verbs.get, `conversation/${ conversationId }/analysis`, null, (error) => {
+		)(verbs.get, `conversation/${ conversationId }/analysis`, null, null, (error) => {
 			// 404 is expected if no mapping exists
 			if (error.response && error.response.statusCode === 404) {
 				return null;
@@ -70,30 +70,26 @@ Meteor.methods({
 					return !RocketChat.authz.hasPermission(userId, 'send-many-messages');
 				}
 			}
-		)(verbs.get, `conversation/${ conversationId }/analysis/template/${ templateIndex }/result/${ creator }?start=${ start }&rows=${ rows }`);
+		)(verbs.get, `conversation/${ conversationId }/analysis/template/${ templateIndex }/result/${ creator }`, { start, rows });
 	},
 
 	searchConversations(queryParams) {
 
-		const _getAclQuery = function() {
+		function unique(value, index, array) {
+			return array.indexOf(value) === index;
+		}
 
-			function unique(value, index, array) {
-				return array.indexOf(value) === index;
-			}
+		const solrFilterBooleanLimit = 256; // there is a limit for boolean expressinos in a filter query of default 1024 and an additional limiter by the HTTP-server. Experiments showed this limit as magic number.
+		const findOptions = { limit: solrFilterBooleanLimit, sort: { ts: -1 }, fields: { _id: 1 } };
+		const subscribedRooms = RocketChat.models.Subscriptions.find({'u._id': Meteor.userId()}, { limit: solrFilterBooleanLimit, sort: { ts: -1 }, fields: { rid: 1 } }).fetch().map(subscription => subscription.rid);
+		const publicChannels = RocketChat.authz.hasPermission(Meteor.userId(), 'view-c-room') ? RocketChat.models.Rooms.find({t: 'c'}, findOptions).fetch().map(room => room._id) : [];
+		const livechats = RocketChat.authz.hasPermission(Meteor.userId(), 'view-l-room') ? RocketChat.models.Rooms.find({t: 'l'}, findOptions).fetch().map(room => room._id) : [];
 
-			const solrFilterBooleanLimit = 256; // there is a limit for boolean expressinos in a filter query of default 1024 and an additional limiter by the HTTP-server. Experiments showed this limit as magic number.
-			const findOptions = { limit: solrFilterBooleanLimit, sort: { ts: -1 }, fields: { _id: 1 } };
-			const subscribedRooms = RocketChat.models.Subscriptions.find({'u._id': Meteor.userId()}, { limit: solrFilterBooleanLimit, sort: { ts: -1 }, fields: { rid: 1 } }).fetch().map(subscription => subscription.rid);
-			const publicChannels = RocketChat.authz.hasPermission(Meteor.userId(), 'view-c-room') ? RocketChat.models.Rooms.find({t: 'c'}, findOptions).fetch().map(room => room._id) : [];
-			const livechats = RocketChat.authz.hasPermission(Meteor.userId(), 'view-l-room') ? RocketChat.models.Rooms.find({t: 'l'}, findOptions).fetch().map(room => room._id) : [];
+		const accessibleRooms = livechats.concat(subscribedRooms).concat(publicChannels);
 
-			const accessibleRooms = livechats.concat(subscribedRooms).concat(publicChannels);
-
-			const filterCriteria = `${ accessibleRooms.filter(unique).slice(0, solrFilterBooleanLimit).join(' OR ') }`;
-			return filterCriteria
-				? `&fq=meta_channel_id:(${ filterCriteria })`
-				: '&fq=meta_channel_id:""'; //fallback: if the user's not authorized to view any room, filter for "nothing"
-		};
+		let fq = `${ accessibleRooms.filter(unique).slice(0, solrFilterBooleanLimit).join(' OR ') }`;
+		fq = fq ? { fq: `meta_channel_id:(${ fq })` } : { fq: 'meta_channel_id:""'}; //fallback: if the user's not authorized to view any room, filter for "nothing"
+		const params = Object.assign(queryParams, fq);
 
 		const queryString = querystring.stringify(queryParams);
 		SystemLogger.debug('QueryString: ', queryString);
@@ -103,7 +99,7 @@ Meteor.methods({
 					return !RocketChat.authz.hasPermission(userId, 'send-many-messages');
 				}
 			}
-		)(verbs.get, `conversation/search?${ queryString }${ _getAclQuery() }`);
+		)(verbs.get, 'conversation/search', params);
 		SystemLogger.debug('SearchResult: ', JSON.stringify(searchResult, null, 2));
 		return searchResult;
 	}


### PR DESCRIPTION
This PR aims to make use of the `params` option within the SmartiProxy - instead of building complex query strings manually and care about encoding.

The Meteor API for `HTTP.call()` supports several options for creating HTTP requests. It is possible to use syntactically correct URLs containing the complete query string. This is what we're currently doing within the `SmartiProxy.propagateToSmarti()` implementation.

Alternately it is possible to use the option `params` - a dictionary of request parameters to be encoded and placed in the URL (for GETs) or request body (for POSTs). If `content` or `data` is specified, `params` will always be placed in the URL. (https://docs.meteor.com/api/http.html)

This enables to pass the query string as an Object, what makes the life much more easier if it comes to URL encoding or building long HTTP query strings by hand.