### PR TITLE
Fixed problem with migrating users without usernames

### DIFF
--- a/packages/assistify-migrations/server/startup/migrations.js
+++ b/packages/assistify-migrations/server/startup/migrations.js
@@ -16,7 +16,7 @@ Meteor.startup(() => {
 
 	const usersWithoutName = RocketChat.models.Users.find({name: null}).fetch();
 	usersWithoutName.forEach((user)=>{
-		RocketChat.models.Users.update({_id: user._id}, {$set: {name: _guessNameFromUsername(user.username, user.email)}});
+		RocketChat.models.Users.update({_id: user._id}, {$set: {name: _guessNameFromUsername(user.username, user.emails[0].address)}});
 	});
 
 });

--- a/packages/assistify-migrations/server/startup/migrations.js
+++ b/packages/assistify-migrations/server/startup/migrations.js
@@ -6,8 +6,8 @@ on startup which migrate data - ignoring the actual version
 
 Meteor.startup(() => {
 
-	const _guessNameFromUsername = function(username) {
-		return username
+	const _guessNameFromUsername = function(username = '', email = '') {
+		return (username || email.replace(/@.*/, ''))
 			.replace(/\W/g, ' ')
 			.replace(/\s(.)/g, function($1) { return $1.toUpperCase(); })
 			.replace(/^(.)/, function($1) { return $1.toLowerCase(); })
@@ -16,7 +16,7 @@ Meteor.startup(() => {
 
 	const usersWithoutName = RocketChat.models.Users.find({name: null}).fetch();
 	usersWithoutName.forEach((user)=>{
-		RocketChat.models.Users.update({_id: user._id}, {$set: {name: _guessNameFromUsername(user.username)}});
+		RocketChat.models.Users.update({_id: user._id}, {$set: {name: _guessNameFromUsername(user.username, user.email)}});
 	});
 
 });

--- a/packages/assistify-migrations/server/startup/migrations.js
+++ b/packages/assistify-migrations/server/startup/migrations.js
@@ -16,7 +16,9 @@ Meteor.startup(() => {
 
 	const usersWithoutName = RocketChat.models.Users.find({name: null}).fetch();
 	usersWithoutName.forEach((user)=>{
-		RocketChat.models.Users.update({_id: user._id}, {$set: {name: _guessNameFromUsername(user.username, user.emails[0].address)}});
+		if (user.username || (user.emails && user.emails.length > 0)) {
+			RocketChat.models.Users.update({_id: user._id}, {$set: {name: _guessNameFromUsername(user.username, user.emails[0].address)}});
+		}
 	});
 
 });


### PR DESCRIPTION
Fixes a problem with migrating users without usernames.

In such cases the e-mail address is taken and the @servername part is stripped off, so that a username can always be set. At least as far as we know, there is no user without an e-mail address.