### PR TITLE
Don't load the Smarti Widget if Smarti is disabled

### DIFF
--- a/packages/assistify-ai/server/lib/SmartiAdapter.js
+++ b/packages/assistify-ai/server/lib/SmartiAdapter.js
@@ -19,6 +19,10 @@ function terminateCurrentSync() {
  */
 export class SmartiAdapter {
 
+	static isEnabled() {
+		return !!RocketChat.settings.get('Assistify_AI_Enabled');
+	}
+
 	/**
 	 * Returns the webhook URL that reveives the analysis callback from Smarti.
 	 */

--- a/packages/assistify-ai/server/methods/SmartiWidgetBackend.js
+++ b/packages/assistify-ai/server/methods/SmartiWidgetBackend.js
@@ -114,22 +114,25 @@ let script;
 let timeoutHandle;
 
 function loadSmarti() {
-
-	let script = RocketChat.RateLimiter.limitFunction(
-		SmartiProxy.propagateToSmarti, 5, 1000, {
-			userId(userId) {
-				return !RocketChat.authz.hasPermission(userId, 'send-many-messages');
+	if (SmartiAdapter.isEnabled()) {
+		let script = RocketChat.RateLimiter.limitFunction(
+			SmartiProxy.propagateToSmarti, 5, 1000, {
+				userId(userId) {
+					return !RocketChat.authz.hasPermission(userId, 'send-many-messages');
+				}
 			}
+		)(verbs.get, 'plugin/v1/rocket.chat.js');
+		if (!script.error && script) {
+			// add pseudo comment in order to make the script appear in the frontend as a file. This makes it de-buggable
+			script = `${ script } //# sourceURL=SmartiWidget.js`;
+		} else {
+			SystemLogger.error('Could not load Smarti script from', '${SMARTI-SERVER}/plugin/v1/rocket.chat.js');
+			throw new Meteor.Error('no-smarti-ui-script', 'no-smarti-ui-script');
 		}
-	)(verbs.get, 'plugin/v1/rocket.chat.js');
-	if (script) {
-		// add pseudo comment in order to make the script appear in the frontend as a file. This makes it de-buggable
-		script = `${ script } //# sourceURL=SmartiWidget.js`;
+		return script;
 	} else {
-		SystemLogger.error('Could not load Smarti script from', '${SMARTI-SERVER}/plugin/v1/rocket.chat.js');
-		throw new Meteor.Error('no-smarti-ui-script', 'no-smarti-ui-script');
+		return ''; // there is no script to be added, so return an empty source (and not null) - hte consumer expects a string
 	}
-	return script;
 }
 
 function delayedReload() {


### PR DESCRIPTION
This PR fixes the handling of the Smarti-Server not being available:

- The error which is returned is not propagated erroneously as object to the client
- In general, the Smarti-Widget is not being loaded anymore once Smarti is configured as disabled

The combination of those two errors prevented the Client from loading the application