### PR TITLE
Add message action to copy message to input as reply

### DIFF
--- a/packages/rocketchat-message-action/client/messageAction.html
+++ b/packages/rocketchat-message-action/client/messageAction.html
@@ -9,7 +9,7 @@
 				{{/if}}
 
 				{{#if msg_in_chat_window}}
-					<button class="js-actionButton-sendMessage" value="{{msg}}">
+					<button class="{{jsActionButtonClassname msg_processing_type}}" value="{{msg}}">
 						<img class="image-button" src="{{image_url}}" />
 					</button>
 				{{/if}}
@@ -21,7 +21,7 @@
 					</a>
 				{{/if}}
 				{{#if msg_in_chat_window}}
-					<button class="text-button js-actionButton-sendMessage" value="{{msg}}">
+					<button class="text-button {{jsActionButtonClassname msg_processing_type}}" value="{{msg}}">
 						<span class="overflow-ellipsis">{{text}}</span>
 					</button>
 				{{/if}}

--- a/packages/rocketchat-message-action/client/messageAction.js
+++ b/packages/rocketchat-message-action/client/messageAction.js
@@ -5,4 +5,7 @@ Template.messageAction.helpers({
 	areButtonsHorizontal() {
 		return Template.parentData(1).button_alignment === 'horizontal';
 	},
+	jsActionButtonClassname(processingType) {
+		return `js-actionButton-${ processingType || 'sendMessage' }`;
+	},
 });

--- a/packages/rocketchat-ui/client/views/app/room.js
+++ b/packages/rocketchat-ui/client/views/app/room.js
@@ -846,6 +846,18 @@ Template.room.events({
 			Meteor.call('sendMessage', msgObject);
 		});
 	},
+	'click .js-actionButton-respondWithMessage'(event) {
+		const msg = event.currentTarget.value;
+		if (!msg) {
+			return;
+		}
+
+		const input = $('.messages-container .rc-message-box .rc-message-box__textarea').get(0);
+		input.value = msg;
+		setTimeout(() => {
+			input.focus();
+		}, 5);
+	},
 });
 
 


### PR DESCRIPTION
## Motivation

As a developer of a bot, I want to suggest a response to the user. Instead of just making the user to send a fully predefined message, the user shall adjust the message (think of it as a template for the reply).
This reduces typing overhead, reduces errors during the conversation and makes sure the user follows some expected structure

## Implementation

There already was a `message-action` to send a message by clicking a button living in an attachment.
This enhancement allows to create an action button (either from an integration, an API or a bot) which copies a predefined message as template into the message input (browser only!)

## Consumption

The button is part of an attachment's actions and can be created anywhere there is a message being created. 
Sample for an outgoing integration

```javascript
class Script{
  
    prepare_outgoing_request({ request }) {

      return {
        message: {
          text: "Would you be so kind to let me know what you did today?",
          attachments: [{
            actions: [
              {
                type: "button",
                msg_in_chat_window: true,
                msg_processing_type: "respondWithMessage",
                text: "Respond easily",
                msg: "**What I worked on today**\n- \n\n**What I am planning to do tomorrow**\n- "
              }
            ]
            }]
        }
      }
    }
}

```

## How it looks like

Sample: A Daily-Bot is gathering input from users:
![2018-11-15 08 08 01](https://user-images.githubusercontent.com/17176678/48536065-b3e64900-e8ad-11e8-886d-c390a1cfc6ea.gif)

## Open issues

Mobile adaption - since this is a client side action, the mobile apps would have to implement this copy-to-input as well.