### PR TITLE
added label to modify connection to agent message

### DIFF
--- a/packages/rocketchat-livechat/.app/client/stylesheets/utils/_loading.import.less
+++ b/packages/rocketchat-livechat/.app/client/stylesheets/utils/_loading.import.less
@@ -1,6 +1,7 @@
 .loading-animation {
 	color: @secondary-font-color;
 	font-size: 1.3rem;
+	line-height: 1.6rem;
 	margin-left: 32px;
 	margin-top: 12px;
 	margin-bottom: 5px;

--- a/packages/rocketchat-livechat/.app/i18n/de.i18n.json
+++ b/packages/rocketchat-livechat/.app/i18n/de.i18n.json
@@ -10,6 +10,7 @@
   "Choose_a_new_department": "Wählen Sie eine neue Abteilung aus",
   "Close_menu": "Menü schließen",
   "Conversation_finished": "Gespräch beendet",
+  "Connecting_to_an_Agent": "Verbinde mit einem Agenten",
   "End_chat": "Chat beenden",
   "How_friendly_was_the_chat_agent": "Wie freundlich war der Chat-Agent?",
   "How_knowledgeable_was_the_chat_agent": "Wie sachkundig war der Chat-Agent?",

--- a/packages/rocketchat-livechat/.app/i18n/de.i18n.json
+++ b/packages/rocketchat-livechat/.app/i18n/de.i18n.json
@@ -10,7 +10,7 @@
   "Choose_a_new_department": "Wählen Sie eine neue Abteilung aus",
   "Close_menu": "Menü schließen",
   "Conversation_finished": "Gespräch beendet",
-  "Connecting_to_an_Agent": "Verbinde mit einem Agenten",
+  "Connecting_to_an_Agent": "Ihr Anliegen ist uns wichtig. Wir sind gleich für Sie da. ",
   "End_chat": "Chat beenden",
   "How_friendly_was_the_chat_agent": "Wie freundlich war der Chat-Agent?",
   "How_knowledgeable_was_the_chat_agent": "Wie sachkundig war der Chat-Agent?",

--- a/packages/rocketchat-livechat/.app/i18n/en.i18n.json
+++ b/packages/rocketchat-livechat/.app/i18n/en.i18n.json
@@ -10,7 +10,7 @@
   "Choose_a_new_department": "Choose a new department",
   "Close_menu": "Close menu",
   "Conversation_finished": "Conversation finished",
-  "Connecting_to_an_Agent": "Connecting to an agent",
+  "Connecting_to_an_Agent": "Your issue matters to us. We are there for you right away. ",
   "End_chat": "End chat",
   "How_friendly_was_the_chat_agent": "How friendly was the chat agent?",
   "How_knowledgeable_was_the_chat_agent": "How knowledgeable was the chat agent?",

--- a/packages/rocketchat-livechat/.app/i18n/en.i18n.json
+++ b/packages/rocketchat-livechat/.app/i18n/en.i18n.json
@@ -10,6 +10,7 @@
   "Choose_a_new_department": "Choose a new department",
   "Close_menu": "Close menu",
   "Conversation_finished": "Conversation finished",
+  "Connecting_to_an_Agent": "Verbinde mit einem Agenten EN",
   "End_chat": "End chat",
   "How_friendly_was_the_chat_agent": "How friendly was the chat agent?",
   "How_knowledgeable_was_the_chat_agent": "How knowledgeable was the chat agent?",

--- a/packages/rocketchat-livechat/.app/i18n/en.i18n.json
+++ b/packages/rocketchat-livechat/.app/i18n/en.i18n.json
@@ -10,7 +10,7 @@
   "Choose_a_new_department": "Choose a new department",
   "Close_menu": "Close menu",
   "Conversation_finished": "Conversation finished",
-  "Connecting_to_an_Agent": "Verbinde mit einem Agenten EN",
+  "Connecting_to_an_Agent": "Connecting to an agent",
   "End_chat": "End chat",
   "How_friendly_was_the_chat_agent": "How friendly was the chat agent?",
   "How_knowledgeable_was_the_chat_agent": "How knowledgeable was the chat agent?",

--- a/packages/rocketchat-livechat/.app/i18n/en.i18n.json
+++ b/packages/rocketchat-livechat/.app/i18n/en.i18n.json
@@ -10,7 +10,7 @@
   "Choose_a_new_department": "Choose a new department",
   "Close_menu": "Close menu",
   "Conversation_finished": "Conversation finished",
-  "Connecting_to_an_Agent": "Your issue matters to us. We are there for you right away. ",
+  "Connecting_to_an_Agent": "Your request is important to us. We are there for you right away. ",
   "End_chat": "End chat",
   "How_friendly_was_the_chat_agent": "How friendly was the chat agent?",
   "How_knowledgeable_was_the_chat_agent": "How knowledgeable was the chat agent?",


### PR DESCRIPTION
Added a label for "Connection_to_an_agent" message:

![image](https://user-images.githubusercontent.com/11913979/49007473-d872d880-f16b-11e8-8a84-fa798a284873.png)

It is not possible to set a custom translation for the label, since the label only exists in the livechat.i18n files.