### PR TITLE
[FIX] Smarti performance by on-demand-analysis

### DIFF
--- a/packages/assistify-ai/client/views/app/tabbar/smarti.js
+++ b/packages/assistify-ai/client/views/app/tabbar/smarti.js
@@ -21,8 +21,8 @@ Template.AssistifySmarti.onCreated(function() {
 	the user is interested in what Smarti is analyzing =>
 	register a callback which triggers an analysis asynchronously
 	*/
-	RocketChat.callbacks.add('streamMessage', () => {
-		Meteor.call('analyze', instance.data.rid);
+	RocketChat.callbacks.add('streamMessage', (message) => {
+		Meteor.call('analyze', message.rid);
 	}, RocketChat.callbacks.priority.LOW, 'smarti-analysis');
 
 });

--- a/packages/assistify-ai/server/SmartiProxy.js
+++ b/packages/assistify-ai/server/SmartiProxy.js
@@ -57,10 +57,7 @@ export class SmartiProxy {
 		} catch (error) {
 
 			if (error && onError) {
-				const recoveryResult = onError(error);
-				if (recoveryResult !== undefined) {
-					return recoveryResult;
-				}
+				return onError(error);
 			}
 
 			SystemLogger.error('Could not complete', method, 'to', url, error.response);

--- a/packages/assistify-ai/server/lib/SmartiAdapter.js
+++ b/packages/assistify-ai/server/lib/SmartiAdapter.js
@@ -111,7 +111,6 @@ export class SmartiAdapter {
 
 			if (request_result) {
 				Meteor.defer(() => SmartiAdapter._markMessageAsSynced(message._id));
-				SmartiAdapter._getAnalysisResult(message.rid, conversationId);
 				// autosync: If a room was not in sync, but the new message could be synced, try to sync the room again
 				Meteor.defer(() => SmartiAdapter._tryResync(message.rid, false));
 			} else {
@@ -136,7 +135,6 @@ export class SmartiAdapter {
 		if (conversationId) {
 			SystemLogger.debug(`Smarti - Deleting message ${ message.rid } from conversation ${ conversationId }.`);
 			SmartiProxy.propagateToSmarti(verbs.delete, `conversation/${ conversationId }/message/${ message._id }`);
-			SmartiAdapter._getAnalysisResult(message.rid, conversationId);
 		} else {
 			SystemLogger.error(`Smarti - deleting message from conversation faild after delete message [ id: ${ message._id } ] from room [ id: ${ message.rid } ]`);
 		}
@@ -237,7 +235,7 @@ export class SmartiAdapter {
 	/**
 	 * Updates the mapping and triggers an asynchronous analysis.
 	 */
-	static _getAnalysisResult(roomId, conversationId) {
+	static getAnalysisResult(roomId, conversationId) {
 
 		// conversation updated or created => request analysis results
 		SystemLogger.debug(`Smarti - conversation updated or created -> get analysis result asynch [ callback=${ SmartiAdapter.rocketWebhookUrl } ] for conversation: ${ conversationId } and room: ${ roomId }`);

--- a/packages/assistify-ai/server/lib/SmartiAdapter.js
+++ b/packages/assistify-ai/server/lib/SmartiAdapter.js
@@ -235,8 +235,8 @@ export class SmartiAdapter {
 	/**
 	 * Updates the mapping and triggers an asynchronous analysis.
 	 */
-	static getAnalysisResult(roomId, conversationId) {
-
+	static triggerAnalysis(roomId) {
+		const conversationId = SmartiAdapter.getConversationId(roomId);
 		// conversation updated or created => request analysis results
 		SystemLogger.debug(`Smarti - conversation updated or created -> get analysis result asynch [ callback=${ SmartiAdapter.rocketWebhookUrl } ] for conversation: ${ conversationId } and room: ${ roomId }`);
 		SmartiProxy.propagateToSmarti(verbs.get, `conversation/${ conversationId }/analysis`, { callback: SmartiAdapter.rocketWebhookUrl }); // asynch

--- a/packages/assistify-ai/server/methods/SmartiWidgetBackend.js
+++ b/packages/assistify-ai/server/methods/SmartiWidgetBackend.js
@@ -51,6 +51,21 @@ Meteor.methods({
 	},
 
 	/**
+	 * This method provides the client a handler to request the asynchronous analysis of a room's messages
+	 * It can e. g. be issued from the widget once it's opened
+	 * @param {*} roomId The ID of the Rocket.Chat room which shall be analyzed
+	 */
+	analyze(roomId) {
+		return RocketChat.RateLimiter.limitFunction(
+			SmartiAdapter.triggerAnalysis, 5, 1000, {
+				userId(userId) {
+					return !RocketChat.authz.hasPermission(userId, 'send-many-messages');
+				},
+			}
+		)(roomId);
+	},
+
+	/**
 	 * Returns the query builder results for the given conversation (used by Smarti widget)
 	 *
 	 * @param {String} conversationId - the conversation id to get results for


### PR DESCRIPTION

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #551 

## What this solves

Up to now, each message lead to an (asynchronous) analysis of the conversation in Smarti. While it was asynchronous for the consuming Rocket.Chat, it was instantly queued on the Smarti-side. 
Having this triggered for all CUD-operations on messages, this created a huge load.

## What is changing

Now, the analysis is only triggered once the widget is opened (the user is interested in Smarti's results), the analysis is being requested.
This leads to a longer delay, but much reduced total load.

## How it's been done

The triggering of the analysis after message sent/updated has been completely removed. Now, only the state of the conversation is propagated (without any further processing).

Only once the Smarti tab is opened, the analysis is being requested and a callback **on the client** is being registered. This callback itself calls a method triggering an analysis server-side - asynchronously, of course.
Once the callback is reached from Smarti, the already existing mechanism to update the widget (propagate the event of the result) is used.