### PR TITLE
Smarti frontend token filtering

### DIFF
--- a/packages/assistify-ai/client/messageRenderer.js
+++ b/packages/assistify-ai/client/messageRenderer.js
@@ -7,18 +7,23 @@ import s from 'underscore.string';
  * @param {*} message the message object including all properties
  * @augments message.html - the rendered message body
  */
-const highlightRecognizedTerms = function(message) {
-	const { recognizedTerms } = message;
+const highlightrecognizedTokens = function(message) {
+	const { recognizedTokens } = message;
 	if (RocketChat.settings.get('Assistify_AI_Smarti_Inline_Highlighting_Enabled')) {
+		const confExcluded = RocketChat.settings.get('Assistify_AI_Smarti_Inline_Highlighting_Excluded_Types');
+		const excludedTypes = confExcluded ? new Set(confExcluded.split(',').map((item) => item.trim())) : new Set();
+
 		let { html } = message;
-		if (recognizedTerms) {
-			recognizedTerms.forEach((term) => {
-				const regexpFindTerm = `(^|\\b|[\\s.,،'\\\"\\+!?:-])(${ s.escapeRegExp(term) })($|\\b|[\\s.,،'\\\"\\+!?:-])`;
-				html = html.replace(new RegExp(regexpFindTerm, 'gmi'), '$1<span class="recognized-term"><span class="text">$2</span></span>$3');
+		if (recognizedTokens) {
+			recognizedTokens.forEach((term) => {
+				if (!excludedTypes.has(term.type)) {
+					const regexpFindTerm = `(^|\\b|[\\s.,،'\\\"\\+!?:-])(${ s.escapeRegExp(term.value) })($|\\b|[\\s.,،'\\\"\\+!?:-])`;
+					html = html.replace(new RegExp(regexpFindTerm, 'gmi'), '$1<span class="recognized-term"><span class="text">$2</span></span>$3');
+				}
 			});
 		}
 		message.html = html;
 	}
 };
 
-RocketChat.callbacks.add('renderMessage', highlightRecognizedTerms, RocketChat.callbacks.priority.LOW, 'smartiHighlighting');
+RocketChat.callbacks.add('renderMessage', highlightrecognizedTokens, RocketChat.callbacks.priority.LOW, 'smartiHighlighting');

--- a/packages/assistify-ai/client/messageRenderer.js
+++ b/packages/assistify-ai/client/messageRenderer.js
@@ -22,9 +22,10 @@ const highlightrecognizedTokens = function(message) {
 						we'll remove it for this processing since else, the negative lookahead of the regex,
 						which prevents replacement inside html-tags such as links, will prevent replacing of any content
 					*/
-					const wrappedInParagraph = html.substr(0, 3) === '<p>' && html.substr(html.length - 5, 4) === '</p>';
+					html = html.trim();
+					const wrappedInParagraph = html.startsWith('<p>') && html.endsWith('</p>');
 					if (wrappedInParagraph) {
-						html = html.substr(3, html.length - 8);
+						html = html.substr(3, html.length - 7);
 					}
 					const regexpFindTerm = `(^|\\b|[\\s.,،'\\\"\\+!?:-])(${ s.escapeRegExp(term.value) })($|\\b|[\\s.,،'\\\"\\+!?:-])(?![^<]*>|[^<>]*<\\/)`;
 					html = html.replace(new RegExp(regexpFindTerm, 'gmi'), '$1<span class="recognized-term"><span class="text">$2</span></span>$3');

--- a/packages/assistify-ai/client/messageRenderer.js
+++ b/packages/assistify-ai/client/messageRenderer.js
@@ -17,8 +17,20 @@ const highlightrecognizedTokens = function(message) {
 		if (recognizedTokens) {
 			recognizedTokens.forEach((term) => {
 				if (!excludedTypes.has(term.type)) {
-					const regexpFindTerm = `(^|\\b|[\\s.,،'\\\"\\+!?:-])(${ s.escapeRegExp(term.value) })($|\\b|[\\s.,،'\\\"\\+!?:-])`;
+
+					/* depending on the previous renderers, the content of the message will be wrapped in a <p>
+						we'll remove it for this processing since else, the negative lookahead of the regex,
+						which prevents replacement inside html-tags such as links, will prevent replacing of any content
+					*/
+					const wrappedInParagraph = html.substr(0, 3) === '<p>' && html.substr(html.length - 5, 4) === '</p>';
+					if (wrappedInParagraph) {
+						html = html.substr(3, html.length - 8);
+					}
+					const regexpFindTerm = `(^|\\b|[\\s.,،'\\\"\\+!?:-])(${ s.escapeRegExp(term.value) })($|\\b|[\\s.,،'\\\"\\+!?:-])(?![^<]*>|[^<>]*<\\/)`;
 					html = html.replace(new RegExp(regexpFindTerm, 'gmi'), '$1<span class="recognized-term"><span class="text">$2</span></span>$3');
+					if (wrappedInParagraph) {
+						html = `<p>${ html }</p>`;
+					}
 				}
 			});
 		}

--- a/packages/assistify-ai/client/public/stylesheets/smarti.css
+++ b/packages/assistify-ai/client/public/stylesheets/smarti.css
@@ -143,7 +143,7 @@
 .recognized-term {
 	cursor: pointer;
 
-	color: #d5195b;
+	color: #00403a;
 }
 
 .recognized-term .text {

--- a/packages/assistify-ai/models/MessagesExtension.js
+++ b/packages/assistify-ai/models/MessagesExtension.js
@@ -1,7 +1,7 @@
 import { RocketChat } from 'meteor/rocketchat:lib';
 
 Object.assign(RocketChat.models.Messages, {
-	setRecognizedTermsById(id, recognizedTerms) {
-		return this.update({ _id: id }, { $set: { recognizedTerms } });
+	setRecognizedTokensById(id, recognizedTokens) {
+		return this.update({ _id: id }, { $set: { recognizedTokens } });
 	},
 });


### PR DESCRIPTION
This PR moves the filtering of identified tokens to the frontend:
Now, all identified tokens are persisted for the message, even if they are of a type which shall not be highlighted (e. g `Attribute`).

Additionally, it prevents content from HTML-tags to be replaced.