### PR TITLE
Fix highlight in markdown rendered texts and multiline translations

### DIFF
--- a/packages/assistify-ai/client/messageRenderer.js
+++ b/packages/assistify-ai/client/messageRenderer.js
@@ -22,10 +22,10 @@ const highlightrecognizedTokens = function(message) {
 						we'll remove it for this processing since else, the negative lookahead of the regex,
 						which prevents replacement inside html-tags such as links, will prevent replacing of any content
 					*/
-					html = html.trim();
-					const wrappedInParagraph = html.startsWith('<p>') && html.endsWith('</p>');
+					const regexWrappedParagraph = new RegExp('^\s*<p>|<\/p>\s*$', 'gm');
+					const wrappedInParagraph = html.search(regexWrappedParagraph) >= 0;
 					if (wrappedInParagraph) {
-						html = html.substr(3, html.length - 7);
+						html = html.replace(regexWrappedParagraph, '');
 					}
 					const regexpFindTerm = `(^|\\b|[\\s.,،'\\\"\\+!?:-])(${ s.escapeRegExp(term.value) })($|\\b|[\\s.,،'\\\"\\+!?:-])(?![^<]*>|[^<>]*<\\/)`;
 					html = html.replace(new RegExp(regexpFindTerm, 'gmi'), '$1<span class="recognized-term"><span class="text">$2</span></span>$3');

--- a/packages/rocketchat-autotranslate/server/autotranslate.js
+++ b/packages/rocketchat-autotranslate/server/autotranslate.js
@@ -139,11 +139,11 @@ export class AutoTranslate {
 		let count = message.tokens.length;
 		message.html = message.msg;
 		message = RocketChat.Markdown.parseMessageNotEscaped(message);
-		message.msg = message.html.trim();
 		// Some parsers (e. g. Marked) wrap the complete message in a <p> - this is unnecessary and should be ignored with respect to translations
-		const wrappedInParagraph = message.msg.startsWith('<p>') && message.msg.endsWith('</p>');
+		const regexWrappedParagraph = new RegExp('^\s*<p>|<\/p>\s*$', 'gm');
+		const wrappedInParagraph = message.msg.search(regexWrappedParagraph) >= 0;
 		if (wrappedInParagraph) {
-			message.msg = message.msg.substr(3, message.msg.length - 7);
+			message.msg = message.msg.replace(regexWrappedParagraph, '');
 		}
 
 		for (const tokenIndex in message.tokens) {

--- a/packages/rocketchat-autotranslate/server/autotranslate.js
+++ b/packages/rocketchat-autotranslate/server/autotranslate.js
@@ -141,10 +141,7 @@ export class AutoTranslate {
 		message = RocketChat.Markdown.parseMessageNotEscaped(message);
 		// Some parsers (e. g. Marked) wrap the complete message in a <p> - this is unnecessary and should be ignored with respect to translations
 		const regexWrappedParagraph = new RegExp('^\s*<p>|<\/p>\s*$', 'gm');
-		const wrappedInParagraph = message.msg.search(regexWrappedParagraph) >= 0;
-		if (wrappedInParagraph) {
-			message.msg = message.msg.replace(regexWrappedParagraph, '');
-		}
+		message.msg = message.msg.replace(regexWrappedParagraph, '');
 
 		for (const tokenIndex in message.tokens) {
 			if (message.tokens.hasOwnProperty(tokenIndex)) {

--- a/packages/rocketchat-autotranslate/server/deeplTranslate.js
+++ b/packages/rocketchat-autotranslate/server/deeplTranslate.js
@@ -130,10 +130,11 @@ class DeeplAutoTranslate extends AutoTranslate {
 
 				if (result.statusCode === 200 && result.data && result.data.translations && Array.isArray(result.data.translations) && result.data.translations.length > 0) {
 					// store translation only when the source and target language are different.
-					if (result.data.translations.map((translation) => translation.detected_source_language).join() !== language) {
-						const txt = result.data.translations.map((translation) => translation.text);
-						translations[language] = this.deTokenize(Object.assign({}, message, { msg: txt }));
-					}
+					// multiple lines might contain different languages => Mix the text between source and detected target if neccessary
+					const translatedText = result.data.translations
+						.map((translation, index) => (translation.detected_source_language !== language ? translation.text : msgs[index]))
+						.join('\n');
+					translations[language] = this.deTokenize(Object.assign({}, message, { msg: translatedText }));
 				}
 			} catch (e) {
 				SystemLogger.error('Error translating message', e);


### PR DESCRIPTION
Fixes #574

# Motivation

There have been two actually independent issues, which both affected rendering of Markdown decorated, particularly multiline texts.
Earlier-on, we therefore `trim()`-med the incoming text. However, this lead to issues with respect to texts starting with inline monospaced content (single backticks).

Furthermore, multi-line texts to be translated using DeepL have been split into multiple translation paragraphs. Those were also not handled properly til now.

# What's been done

The rendering now deliberately only replaces trailing linebreaks and `<p>` tags.
The translation now translates paragraphs one-by-one, respecting each paragraph's language. This also enables multi language texts