### PR TITLE
Make deploy step of CircelCI dependend of hold step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -432,9 +432,10 @@ workflows:
             - test-without-oplog-mongo-3-4
             - test-without-oplog-mongo-3-6
             - test-without-oplog-mongo-4-0
+            - hold
           filters:
             branches:
-              only: 
+              only:
                 - develop
                 - master
             tags:


### PR DESCRIPTION
The CircleCI config file was overwritten when the new Rocket.Chat version was merged. I re-added the dependency for the `deploy` step on the `hold` step to prevent deployments without explicit approval.