### PR TITLE
Incorporated upstream changes regarding notifications for livechat agents

### DIFF
--- a/packages/rocketchat-livechat/server/lib/QueueMethods.js
+++ b/packages/rocketchat-livechat/server/lib/QueueMethods.js
@@ -88,8 +88,8 @@ RocketChat.QueueMethods = {
 	 * only the client until paired with an agent
 	 */
 	'Guest_Pool'(guest, message, roomInfo) {
+		const onlineAgents = RocketChat.Livechat.getOnlineAgents(guest.department);
 		if (RocketChat.settings.get('Livechat_guest_pool_with_no_agents') === false) {
-			const onlineAgents = RocketChat.Livechat.getOnlineAgents(guest.department);
 			if (!onlineAgents || onlineAgents.count() === 0) {
 				throw new Meteor.Error('no-agent-online', 'Sorry, no online agents');
 			}
@@ -158,15 +158,25 @@ RocketChat.QueueMethods = {
 		RocketChat.models.Rooms.insert(room);
 
 		// Alert the agents of the queued request
-		agentIds.forEach((agentId) => {
+		onlineAgents.forEach((agent) => {
+			const { _id, active, emails, language, status, statusConnection, username } = agent;
+
 			sendNotification({
 				// fake a subscription in order to make use of the function defined above
 				subscription: {
 					rid: room._id,
 					t : room.t,
 					u: {
-						_id : agentId,
+						_id,
 					},
+					receiver: [{
+						active,
+						emails,
+						language,
+						status,
+						statusConnection,
+						username,
+					}],
 				},
 				sender: room.v,
 				hasMentionToAll: true, // consider all agents to be in the room


### PR DESCRIPTION
(see https://github.com/RocketChat/Rocket.Chat/commit/a7f57b273fe3e35d76abc34eb8453a8d25f5a172)

This change complements the changes from https://github.com/assistify/Rocket.Chat/pull/592 by preventing notification e-mails to *all* agents and instead sending notifications only the online agents.