### PR TITLE
Hotfix/#614 autotranslate exceptions

### DIFF
--- a/app/autotranslate/server/autotranslate.js
+++ b/app/autotranslate/server/autotranslate.js
@@ -3,7 +3,7 @@ import { settings } from '../../settings';
 import { callbacks } from '../../callbacks';
 import { Subscriptions, Messages } from '../../models';
 import { Markdown } from '../../markdown/server';
-import { Logger } from '../../logger';
+import { logger } from './logger';
 import _ from 'underscore';
 import s from 'underscore.string';
 
@@ -281,7 +281,7 @@ export class AutoTranslate {
 		};
 	 */
 	_getProviderMetadata() {
-		Logger.warn('must be implemented by subclass!', '_getProviderMetadata');
+		logger.warn('must be implemented by subclass!', '_getProviderMetadata');
 	}
 
 
@@ -293,7 +293,7 @@ export class AutoTranslate {
 	 * @returns [{ language, name }]
 	 */
 	getSupportedLanguages(target) {
-		Logger.warn('must be implemented by subclass!', 'getSupportedLanguages', target);
+		logger.warn('must be implemented by subclass!', 'getSupportedLanguages', target);
 	}
 
 	/**
@@ -306,7 +306,7 @@ export class AutoTranslate {
 	 * @return {object}
 	 */
 	_translateMessage(message, targetLanguages) {
-		Logger.warn('must be implemented by subclass!', '_translateMessage', message, targetLanguages);
+		logger.warn('must be implemented by subclass!', '_translateMessage', message, targetLanguages);
 	}
 
 	/**
@@ -318,7 +318,7 @@ export class AutoTranslate {
 	 * @returns {object} translated messages for each target language
 	 */
 	_translateAttachmentDescriptions(attachment, targetLanguages) {
-		Logger.warn('must be implemented by subclass!', '_translateAttachmentDescriptions', attachment, targetLanguages);
+		logger.warn('must be implemented by subclass!', '_translateAttachmentDescriptions', attachment, targetLanguages);
 	}
 }
 

--- a/app/autotranslate/server/deeplTranslate.js
+++ b/app/autotranslate/server/deeplTranslate.js
@@ -3,7 +3,7 @@
  */
 
 import { TranslationProviderRegistry, AutoTranslate } from './autotranslate';
-import { SystemLogger } from '../../logger/server';
+import { logger } from './logger';
 import { TAPi18n } from 'meteor/tap:i18n';
 import { HTTP } from 'meteor/http';
 import _ from 'underscore';
@@ -139,7 +139,7 @@ class DeeplAutoTranslate extends AutoTranslate {
 					translations[language] = this.deTokenize(Object.assign({}, message, { msg: translatedText }));
 				}
 			} catch (e) {
-				SystemLogger.error('Error translating message', e);
+				logger.deepl.error('Error translating message', e);
 			}
 		});
 		return translations;
@@ -173,7 +173,7 @@ class DeeplAutoTranslate extends AutoTranslate {
 					}
 				}
 			} catch (e) {
-				SystemLogger.error('Error translating message attachment', e);
+				logger.deepl.error('Error translating message attachment', e);
 			}
 		});
 		return translations;

--- a/app/autotranslate/server/googleTranslate.js
+++ b/app/autotranslate/server/googleTranslate.js
@@ -4,7 +4,7 @@
 
 import { TAPi18n } from 'meteor/tap:i18n';
 import { AutoTranslate, TranslationProviderRegistry } from './autotranslate';
-import { SystemLogger } from '../../logger/server';
+import { logger } from './logger';
 import { HTTP } from 'meteor/http';
 import _ from 'underscore';
 
@@ -118,7 +118,7 @@ class GoogleAutoTranslate extends AutoTranslate {
 					translations[language] = this.deTokenize(Object.assign({}, message, { msg: txt }));
 				}
 			} catch (e) {
-				SystemLogger.error('Error translating message', e);
+				logger.google.error('Error translating message', e);
 			}
 		});
 		return translations;
@@ -150,7 +150,7 @@ class GoogleAutoTranslate extends AutoTranslate {
 					translations[language] = result.data.data.translations.map((translation) => translation.translatedText).join('\n');
 				}
 			} catch (e) {
-				SystemLogger.error('Error translating message', e);
+				logger.google.error('Error translating message', e);
 			}
 
 		});

--- a/app/autotranslate/server/logger.js
+++ b/app/autotranslate/server/logger.js
@@ -1,3 +1,8 @@
 import { Logger } from '../../logger';
 
-export const logger = new Logger('AutoTranslate');
+export const logger = new Logger('AutoTranslate', {
+	sections: {
+		google: 'Google',
+		deepl: 'DeepL',
+	},
+});

--- a/app/autotranslate/server/logger.js
+++ b/app/autotranslate/server/logger.js
@@ -1,0 +1,3 @@
+import { Logger } from '../../logger';
+
+export const logger = new Logger('AutoTranslate');

--- a/app/autotranslate/server/methods/translateMessage.js
+++ b/app/autotranslate/server/methods/translateMessage.js
@@ -1,12 +1,12 @@
 import { Meteor } from 'meteor/meteor';
 import { Rooms } from '../../../models';
-import AutoTranslate from '../autotranslate';
+import { TranslationProviderRegistry } from '..';
 
 Meteor.methods({
 	'autoTranslate.translateMessage'(message, targetLanguage) {
 		const room = Rooms.findOneById(message && message.rid);
-		if (message && room && AutoTranslate) {
-			return AutoTranslate.translateMessage(message, room, targetLanguage);
+		if (message && room && TranslationProviderRegistry) {
+			TranslationProviderRegistry.getActiveProvider().translateMessage(message, room, targetLanguage);
 		}
 	},
 });


### PR DESCRIPTION
This closes #614 and also other exceptions occurred during auto translate.

*Issues to test:*

1) Logger.warn is not a function when translating attachment descriptions
2) translateMessage is not a function during translation using the context menu.