### PR TITLE
Remove usage statistics

### DIFF
--- a/app/statistics/server/functions/get.js
+++ b/app/statistics/server/functions/get.js
@@ -148,7 +148,7 @@ statistics.get = function _getStatistics() {
 	statistics.uniqueOSOfYesterday = Sessions.getUniqueOSOfYesterday();
 	statistics.uniqueOSOfLastMonth = Sessions.getUniqueOSOfLastMonth();
 
-	statistics.usages = getUsages();
+//	statistics.usages = getUsages();
 
 	return statistics;
 };


### PR DESCRIPTION
Deactivate usage statistics in order to validate whether the statistics-creation heavily impacts performance