### PR TITLE
Allow managers to view statistics

### DIFF
--- a/app/assistify/configuration/server/roles.js
+++ b/app/assistify/configuration/server/roles.js
@@ -245,6 +245,7 @@ const createManagerRole = function() {
 		'view-full-other-user-info',
 		'view-room-administration',
 		'view-user-administration',
+		'view-statistics',
 	];
 
 	assignPermissions(MANAGER_ROLE_NAME, permissions);


### PR DESCRIPTION
This change allows managers to view statistics about users, rooms and messages.

<img width="1440" alt="Bildschirmfoto 2019-08-27 um 09 15 26" src="https://user-images.githubusercontent.com/17176678/63749265-602c7580-c8ab-11e9-8665-cbbe9ad849fd.png">

