### PR TITLE
Don't skip CircleCI if it's a PR

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -259,7 +259,6 @@ jobs:
       - run:
           name: Publish assets
           command: |
-            if [[ $CIRCLE_PULL_REQUESTS ]]; then exit 0; fi;
             bash .scripts/deploy-assistify-chat.sh
 
   image-build:


### PR DESCRIPTION
This shall actually trigger the deployment script which was skipped earlier