### PR TITLE
Docker: Determine INSTANCE_IP if not injected

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -359,7 +359,7 @@ jobs:
 
             docker login -u $DOCKER_USER -p $DOCKER_PASS
 
-            echo "Build official Docker image"
+            echo "Building custom Docker image"
             cp ~/repo/.docker/Dockerfile .
             docker build -t assistify/chat:pr-$CIRCLE_PR_NUMBER .
             docker push assistify/chat:pr-$CIRCLE_PR_NUMBER

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -430,7 +430,7 @@ workflows:
               only: /^v[0-9]+\.[0-9]+\.[0-9]-[0-9]+\.[0-9]+\.[0-9]+$/
       - pr-image-build:
           requires:
-            - hold
+            - build
           filters:
             branches:
               ignore:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -361,6 +361,7 @@ jobs:
 
             echo "Building custom Docker image"
             cp ~/repo/.docker/Dockerfile .
+            cp ~/repo/.docker/startup.sh .
             docker build -t assistify/chat:pr-$CIRCLE_PR_NUMBER .
             docker push assistify/chat:pr-$CIRCLE_PR_NUMBER
 

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -27,4 +27,5 @@ ENV DEPLOY_METHOD=docker \
 
 EXPOSE 3000
 
-CMD ["node", "main.js"]
+COPY .docker/startup.sh /app/bundle/startup.sh
+CMD ["/bin/bash", "startup.sh"]

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,8 +1,7 @@
 FROM rocketchat/base:8
 
 ADD . /app
-
-MAINTAINER buildmaster@rocket.chat
+COPY .docker/startup.sh /app/bundle/startup.sh
 
 RUN set -x \
  && cd /app/bundle/programs/server \
@@ -27,5 +26,4 @@ ENV DEPLOY_METHOD=docker \
 
 EXPOSE 3000
 
-COPY .docker/startup.sh /app/bundle/startup.sh
 CMD ["/bin/bash", "startup.sh"]

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,7 +1,6 @@
 FROM rocketchat/base:8
 
 ADD . /app
-COPY .docker/startup.sh /app/bundle/startup.sh
 
 RUN set -x \
  && cd /app/bundle/programs/server \
@@ -26,4 +25,4 @@ ENV DEPLOY_METHOD=docker \
 
 EXPOSE 3000
 
-CMD ["/bin/bash", "startup.sh"]
+CMD ["/bin/bash", "/app/startup.sh"]

--- a/.docker/Dockerfile.local
+++ b/.docker/Dockerfile.local
@@ -52,4 +52,5 @@ ENV DEPLOY_METHOD=docker \
 
 EXPOSE 3000
 
-CMD ["node", "main.js"]
+COPY .docker/startup.sh /app/bundle/startup.sh
+CMD ["/bin/bash", "startup.sh"]

--- a/.docker/Dockerfile.local
+++ b/.docker/Dockerfile.local
@@ -27,6 +27,7 @@ FROM assistify/chat-base:stretch
 MAINTAINER buildmaster@rocket.chat
 
 COPY --from=builder /tmp/build/bundle /app/bundle
+COPY .docker/startup.sh /app/bundle/startup.sh
 
 RUN set -x \
  && ls -l /app \
@@ -52,5 +53,4 @@ ENV DEPLOY_METHOD=docker \
 
 EXPOSE 3000
 
-COPY .docker/startup.sh /app/bundle/startup.sh
 CMD ["/bin/bash", "startup.sh"]

--- a/.docker/startup.sh
+++ b/.docker/startup.sh
@@ -1,0 +1,3 @@
+# in a container environment, we may need to determine the INSTANCE_IP
+# for each container so that uploads are working even if load-balanced in a group
+[ -z $INSTANCE_IP ] && $(hostname -i) node main.js || node main.js

--- a/.docker/startup.sh
+++ b/.docker/startup.sh
@@ -1,3 +1,13 @@
 # in a container environment, we may need to determine the INSTANCE_IP
 # for each container so that uploads are working even if load-balanced in a group
-[ -z $INSTANCE_IP ] && $(hostname -i) node main.js || node main.js
+if [ -z $INSTANCE_IP ]
+then 
+    export INSTANCE_IP=$(hostname -i) 
+fi
+
+if [ -z $INSTANCE_IP ]
+then 
+    export INSTANCE_IP=$(curl http://169.254.169.254/latest/meta-data/local-ipv4 --connect-timeout 2) 
+fi
+
+node main.js

--- a/.docker/startup.sh
+++ b/.docker/startup.sh
@@ -2,13 +2,13 @@
 # for each container so that uploads are working even if load-balanced in a group
 if [ -z $INSTANCE_IP ]
 then 
-    INSTANCE_IP=$(hostname -i) 
+    export INSTANCE_IP=$(hostname -i) 
     echo "Got INSTANCE_IP via hostname: $INSTANCE_IP"
 fi
 
 if [ -z $INSTANCE_IP ]
 then 
-    INSTANCE_IP=$(curl -s http://169.254.169.254/latest/meta-data/local-ipv4 --connect-timeout 2) 
+    export INSTANCE_IP=$(curl -s http://169.254.169.254/latest/meta-data/local-ipv4 --connect-timeout 2) 
     echo "Got INSTANCE_IP via ECS metadata API: $INSTANCE_IP"
 fi
 

--- a/.docker/startup.sh
+++ b/.docker/startup.sh
@@ -2,12 +2,14 @@
 # for each container so that uploads are working even if load-balanced in a group
 if [ -z $INSTANCE_IP ]
 then 
-    export INSTANCE_IP=$(hostname -i) 
+    INSTANCE_IP=$(hostname -i) 
+    echo "Got INSTANCE_IP via hostname: $INSTANCE_IP"
 fi
 
 if [ -z $INSTANCE_IP ]
 then 
-    export INSTANCE_IP=$(curl http://169.254.169.254/latest/meta-data/local-ipv4 --connect-timeout 2) 
+    INSTANCE_IP=$(curl -s http://169.254.169.254/latest/meta-data/local-ipv4 --connect-timeout 2) 
+    echo "Got INSTANCE_IP via ECS metadata API: $INSTANCE_IP"
 fi
 
 node main.js

--- a/app/lib/server/index.js
+++ b/app/lib/server/index.js
@@ -1,4 +1,5 @@
 import './startup/email';
+import './startup/env';
 import './startup/oAuthServicesUpdate';
 import './startup/rateLimiter';
 import './startup/robots';

--- a/app/lib/server/startup/env.js
+++ b/app/lib/server/startup/env.js
@@ -1,0 +1,7 @@
+import { Meteor } from 'meteor/meteor';
+
+import { SystemLogger } from '../../../logger';
+
+Meteor.startup(function() {
+	return SystemLogger.info('Environment variables', JSON.stringify(process.env, '', 2));
+});


### PR DESCRIPTION
This PR changes the docker execution command in order to support containerized environments like ECS

Resolves
```I20190829-13:57:15.868(0) server.js:212 UploadProxy ➔ debug Upload URL: /ufs/AmazonS3:Uploads/Awz8kFYRAm8PEqP5t?token=49FA7A6a4b&progress=1 
I20190829-13:57:15.874(0) server.js:212 UploadProxy ➔ debug Wrong instance, proxing to: undefined:3000 
I20190829-13:57:15.885(0) Exception in callback of async function: { Error: getaddrinfo ENOTFOUND undefined undefined:3000     at errnoException (dns.js:50:10)     at GetAddrInfoReqWrap.onlookup [as oncomplete] (dns.js:92:26)   code: 'ENOTFOUND',   errno: 'ENOTFOUND',   syscall: 'getaddrinfo',   hostname: 'undefined',   host: 'undefined',   port: '3000' } 
I20190829-13:57:15.886(0) Exception in callback of async function: { Error: socket hang up     at createHangUpError (_http_client.js:331:15)     at Socket.socketCloseListener (_http_client.js:363:23)     at emitOne (events.js:121:20)     at Socket.emit (events.js:211:7)     at TCP._handle.close [as _onclose] (net.js:557:12) code: 'ECONNRESET' } 
```