### PR TITLE
Set verfication status for users added by a manager

### DIFF
--- a/app/ui-flextab/client/tabs/userEdit.js
+++ b/app/ui-flextab/client/tabs/userEdit.js
@@ -161,7 +161,8 @@ Template.userEdit.events({
 });
 
 Template.userEdit.onCreated(function() {
-	this.user = this.data != null ? this.data.user : undefined;
+	const newUser = { emails: [{ address: [], verified: true }], roles: [], services: {} };
+	this.user = this.data != null ? this.data.user || newUser : undefined;
 	this.roles = this.user ? new ReactiveVar(this.user.roles) : new ReactiveVar([]);
 	this.avatar = new ReactiveVar();
 	this.url = new ReactiveVar('');


### PR DESCRIPTION
When a manager adds a new user, an email is sent to this user containing the password given by the manager. However, if the manager doesn't set the `verified` flag for the new user, currently the new user cannot log in with the password.

A good solution would be to send only a link to the user by email and then ask the user to give a new password and then automatically set the verification status, because the user already verified his/her address by using the link in the email.

To have a quick solution to the current problem, we decided to make instead this fix which just set the verified flag for newly added users in the UI so that the manager doesn't forget to set the flag manually.